### PR TITLE
Share functionality for Dynamic Tree Views

### DIFF
--- a/tree.js
+++ b/tree.js
@@ -102,6 +102,20 @@ window.ViewRegistry = class ViewRegistry {
             orig_onLoggedIn_cb(user);
             document.querySelector(this.SHOW_BTN).click();
         };
+
+        if (location.hash) {
+            this.session.loadUrlHash(Object.keys(views), location.hash);
+        }
+
+        addEventListener("hashchange", (e) => this.onHashChange(e));
+    }
+
+    onHashChange(e) {
+        this.session.loadUrlHash(Object.keys(this.views), e.target.location.hash);
+
+        document.querySelector(this.WT_ID_TEXT).value = this.session.personName;
+        document.querySelector(this.VIEW_SELECT).value = this.session.viewID;
+        document.querySelector(this.SHOW_BTN).click();
     }
 
     // Build the <select> option list from the individual views in the registry.
@@ -311,6 +325,17 @@ window.SessionManager = class SessionManager {
         };
 
         this.lm.login();
+    }
+
+    loadUrlHash(viewIDs, urlHash) {
+        const fields = new URLSearchParams(urlHash.substring(1));
+        this.personName = fields.get("name") || this.personName;
+
+        const viewID = fields.get("view");
+
+        if (viewID && viewIDs.includes(viewID)) {
+            this.viewID = fields.get("view");
+        }
     }
 
     loadCookies() {

--- a/views/baseDynamicTree/WikiTreeDynamicTreeViewer.js
+++ b/views/baseDynamicTree/WikiTreeDynamicTreeViewer.js
@@ -424,7 +424,7 @@
 						<div class="vital-info">
 						  <div class="name">
 						    <a href="https://www.wikitree.com/wiki/${person.getName()}" target="_blank">${person.getDisplayName()}</a>
-						    <span class="tree-links"><a onClick="newTree('${person.getName()}');" href="#"><img src="https://www.wikitree.com/images/icons/pedigree.gif" /></a></span>
+						    <span class="tree-links"><a href="#name=${person.getName()}"><img src="https://www.wikitree.com/images/icons/pedigree.gif" /></a></span>
 						  </div>
 						  <div class="birth vital">${birthString(person)}</div>
 						  <div class="death vital">${deathString(person)}</div>

--- a/views/fanChart/FanChartView.js
+++ b/views/fanChart/FanChartView.js
@@ -147,13 +147,9 @@
                             0,
                             0,
                             270 * (genIndex + 0.5),
+                            (180 - FanChartView.maxAngle) / 2 + 180 + (index * FanChartView.maxAngle) / 2 ** genIndex,
                             (180 - FanChartView.maxAngle) / 2 +
-                                90 +
-                                90 +
-                                (index * FanChartView.maxAngle) / 2 ** genIndex,
-                            (180 - FanChartView.maxAngle) / 2 +
-                                90 +
-                                90 +
+                                180 +
                                 ((index + 1) * FanChartView.maxAngle) / 2 ** genIndex,
                             "wedge" + 2 ** genIndex + "n" + index,
                             "black",
@@ -169,13 +165,9 @@
                             0,
                             270 * (genIndex + 0.5),
                             270 * (genIndex - 0.5),
+                            (180 - FanChartView.maxAngle) / 2 + 180 + (index * FanChartView.maxAngle) / 2 ** genIndex,
                             (180 - FanChartView.maxAngle) / 2 +
-                                90 +
-                                90 +
-                                (index * FanChartView.maxAngle) / 2 ** genIndex,
-                            (180 - FanChartView.maxAngle) / 2 +
-                                90 +
-                                90 +
+                                180 +
                                 ((index + 1) * FanChartView.maxAngle) / 2 ** genIndex,
                             "wedge" + 2 ** genIndex + "n" + index,
                             "black",
@@ -325,13 +317,9 @@
                             0,
                             0,
                             270 * (genIndex + 0.5),
+                            (180 - FanChartView.maxAngle) / 2 + 180 + (index * FanChartView.maxAngle) / 2 ** genIndex,
                             (180 - FanChartView.maxAngle) / 2 +
-                                90 +
-                                90 +
-                                (index * FanChartView.maxAngle) / 2 ** genIndex,
-                            (180 - FanChartView.maxAngle) / 2 +
-                                90 +
-                                90 +
+                                180 +
                                 ((index + 1) * FanChartView.maxAngle) / 2 ** genIndex,
                             "wedge" + 2 ** genIndex + "n" + index,
                             "black",
@@ -344,13 +332,9 @@
                             0,
                             270 * (genIndex + 0.5),
                             270 * (genIndex - 0.5),
+                            (180 - FanChartView.maxAngle) / 2 + 180 + (index * FanChartView.maxAngle) / 2 ** genIndex,
                             (180 - FanChartView.maxAngle) / 2 +
-                                90 +
-                                90 +
-                                (index * FanChartView.maxAngle) / 2 ** genIndex,
-                            (180 - FanChartView.maxAngle) / 2 +
-                                90 +
-                                90 +
+                                180 +
                                 ((index + 1) * FanChartView.maxAngle) / 2 ** genIndex,
                             "wedge" + 2 ** genIndex + "n" + index,
                             "black",
@@ -906,7 +890,7 @@
 						<div class="vital-info">
 						  <div class="name">
 						    <a href="https://www.wikitree.com/wiki/${person.getName()}" target="_blank">${person.getDisplayName()}</a>
-						    <span class="tree-links"><a onClick="newTree('${person.getName()}');" href="#"><img style="width:45px; height:30px;" src="https://apps.wikitree.com/apps/clarke11007/pix/fan180.png" /></a></span>
+						    <span class="tree-links"><a href="#name=${person.getName()}"><img style="width:45px; height:30px;" src="https://apps.wikitree.com/apps/clarke11007/pix/fan180.png" /></a></span>
 						  </div>
 						  <div class="birth vital">${birthString(person)}</div>
 						  <div class="death vital">${deathString(person)}</div>

--- a/views/fractalTree/FractalView.js
+++ b/views/fractalTree/FractalView.js
@@ -346,10 +346,9 @@
                             0,
                             0,
                             270 * (genIndex + 0.5),
-                            (180 - FractalView.maxAngle) / 2 + 90 + 90 + (index * FractalView.maxAngle) / 2 ** genIndex,
+                            (180 - FractalView.maxAngle) / 2 + 180 + (index * FractalView.maxAngle) / 2 ** genIndex,
                             (180 - FractalView.maxAngle) / 2 +
-                                90 +
-                                90 +
+                                180 +
                                 ((index + 1) * FractalView.maxAngle) / 2 ** genIndex,
                             "wedge" + 2 ** genIndex + "n" + index,
                             "black",
@@ -362,10 +361,9 @@
                             0,
                             270 * (genIndex + 0.5),
                             270 * (genIndex - 0.5),
-                            (180 - FractalView.maxAngle) / 2 + 90 + 90 + (index * FractalView.maxAngle) / 2 ** genIndex,
+                            (180 - FractalView.maxAngle) / 2 + 180 + (index * FractalView.maxAngle) / 2 ** genIndex,
                             (180 - FractalView.maxAngle) / 2 +
-                                90 +
-                                90 +
+                                180 +
                                 ((index + 1) * FractalView.maxAngle) / 2 ** genIndex,
                             "wedge" + 2 ** genIndex + "n" + index,
                             "black",
@@ -933,7 +931,7 @@
 						<div class="vital-info">
 						  <div class="name">
 						    <a href="https://www.wikitree.com/wiki/${person.getName()}" target="_blank">${person.getDisplayName()}</a>
-						    <span class="tree-links"><a onClick="newTree('${person.getName()}');" href="#"><img style="width:45px; height:30px;" src="https://apps.wikitree.com/apps/clarke11007/pix/fan180.png" /></a></span>
+						    <span class="tree-links"><a href="#name=${person.getName()}"><img style="width:45px; height:30px;" src="https://apps.wikitree.com/apps/clarke11007/pix/fan180.png" /></a></span>
 						  </div>
 						  <div class="birth vital">${birthString(person)}</div>
 						  <div class="death vital">${deathString(person)}</div>


### PR DESCRIPTION
Fixes bug reported in https://github.com/wikitree/wikitree-dynamic-tree/issues/35

At the same time add functionality for sharing via url (via hash):
- add `#name=Windsor-1` at the end of url and it'll load queen Elisabeth II profile in previously selected view
- add `#name=Windsor-1&view=timeline` at the end of url and it'll load queen Elisabeth II profile in `Timeline` view

As for sharing (and also other actions, like print, export to image, ...) I'm planning to make toolbar with buttons with an option to register your own actions (e.g. settings for the view, ...),  but not in this pull request, but rather as new feature.

Note:
- when I've been fixing some views (removing `onclick` event calling `newTree` and changing `href` of the `a` element to use hash), the prettier also reformatted the code. I don't really like to mess with someone else code, so I can revert it back and fix only those links if original authors won't like this.