### PR TITLE
Update to Ancestor Webs view

### DIFF
--- a/tree.css
+++ b/tree.css
@@ -226,3 +226,6 @@ main {
 .centered {
   text-align: center;
 }
+.marginBottomZero {
+  margin-bottom: 0;
+}

--- a/views/fanChart/AhnenTafel.js
+++ b/views/fanChart/AhnenTafel.js
@@ -84,6 +84,32 @@ AhnenTafel.Ahnentafel = class Ahnentafel {
         }
         return theList;
     }
+    // Returns an array of objects, each one holding the WikiTree ID # and the list of Ahnentafel #s associated with them for each repeat ancestor
+    listOfRepeatAncestors(numGens = 16) {
+        let theList = [];
+        let maxAhnNum = 2**numGens - 1;
+        for (var id in this.listByPerson) {
+            if (this.listByPerson[id] && this.listByPerson[id].length > 1) {
+                if (this.hasTwoAncestorsInThisAhnenRange(this.listByPerson[id] , maxAhnNum)) {
+                    theList.push({ id: id, AhnNums: this.listByPerson[id] });
+                }
+
+            }
+        }
+        return theList;
+    }
+
+    // Wee function to quickly look through a list of AhnenNumbers and determine if there are at least 2 of them within a specific range (determined by max # of gens currently being displayed)
+    hasTwoAncestorsInThisAhnenRange(listOfAhnNums , maxAhnNum) {
+        let numInRange = 0;
+        for (let index = 0; index < listOfAhnNums.length; index++) {
+            if ( listOfAhnNums[index] <= maxAhnNum) {
+                numInRange++;
+            }
+        }
+        
+        return (numInRange >= 2);
+    }    
 
     // Returns an array of objects for building the Fan Chart (and potentially other trees)
     // Each entry contains the Ahnentafel #, and the Person object for each ancestor

--- a/views/fanChart/SettingsOptions.js
+++ b/views/fanChart/SettingsOptions.js
@@ -84,7 +84,7 @@ SettingsOptions.SettingsOptionsObject = class SettingsOptionsObject {
         // console.log("createTabMapping : ", data.tabs);
         let theMapping = {};
         for (let tab in data.tabs) {
-            console.log("createTabMapping - TAB:", tab, data.tabs[tab].name);
+            // console.log("createTabMapping - TAB:", tab, data.tabs[tab].name);
             let tabName = data.tabs[tab].name;
             let theElement = { panelElement: tabName + "-panel", buttonElement: tabName + "-tab" };
             theMapping[tabName] = theElement;
@@ -111,7 +111,7 @@ SettingsOptions.SettingsOptionsObject = class SettingsOptionsObject {
     // input --> data is the object passed through from the Dynamic View that needs the settings
     // this function is used by the createSettingsDIV function, but could be used standalone if you wanted a different wrapper for your settings
     createULelements(data) {
-        console.log("createULelements : ", data.tabs);
+        // console.log("createULelements : ", data.tabs);
         let theUL = "<ul class='profile-tabs'>";
         let theDIVs = "";
         for (let tab in data.tabs) {


### PR DESCRIPTION
This update now shows off more of what this View is supposed to do. There are (currently) 4 viewing modes:

- Full Pedigree Ancestor Tree 
- Unique Ancestor Web (similar to above, but ancestors only appear once, so repeats are connected with multiple lines) 
![image](https://user-images.githubusercontent.com/114438918/196954247-291b8d02-776e-46a0-bfb5-401443c6ea99.png)
- Repeat Ancestors Only Web (similar to above, but terminal ancestors that only appear once are hidden, so the focus is on the repeat ancestors only, and their connection to the primary person)
- Individual Ancestor Web (all paths from a SINGLE repeat ancestor to the primary person)
![image](https://user-images.githubusercontent.com/114438918/196954419-76c0cecb-184f-4563-b66c-13f4b136999b.png)

There are things to tidy up - decisions to make about when to show more than just first initials (e.g. in Individual Mode - I will eventually make first names the default display option, not just initials) - and if repeat ancestors show up in different generations there's some logic I need to add so they only display once)

Test this out using WikiTree ID:  Maione-86  Anna has a small tree, and the repeats happen as early as the 5th generation