### PR TITLE
Fix #hashcode links so they can still be in-page location links

### DIFF
--- a/tree.js
+++ b/tree.js
@@ -113,11 +113,17 @@ window.ViewRegistry = class ViewRegistry {
     }
 
     onHashChange(e) {
-        this.session.loadUrlHash(Object.keys(this.views), e.target.location.hash);
+        // We only want to update our session and view information if the new hash looks like it is supposed to.
+        // Otherwise, it's just a regular in-page hash link "#here" that we should let operate normally.
 
-        document.querySelector(this.WT_ID_TEXT).value = this.session.personName;
-        document.querySelector(this.VIEW_SELECT).value = this.session.viewID;
-        document.querySelector(this.SHOW_BTN).click();
+        let h = e.target.location.hash;
+        if (h.match(/^#name=.+(&view=.+)?/) || h.match(/^#view=.+(&name=.+)?/)) {
+            this.session.loadUrlHash(Object.keys(this.views), e.target.location.hash);
+
+            document.querySelector(this.WT_ID_TEXT).value = this.session.personName;
+            document.querySelector(this.VIEW_SELECT).value = this.session.viewID;
+            document.querySelector(this.SHOW_BTN).click();
+        }
     }
 
     // Build the <select> option list from the individual views in the registry.


### PR DESCRIPTION
Only update the view starting profile and/or view id if the #hash looks like a designation of one or both. If not, don't act on it and leave the link to be treated as an in-page link. For https://github.com/wikitree/wikitree-dynamic-tree/issues/73.