### PR TITLE
fix: stays at selected profile after login

### DIFF
--- a/tree.js
+++ b/tree.js
@@ -321,8 +321,6 @@ window.LoginManager = class LoginManager {
             this.user.name = data.clientLogin.username;
             this.user.id = data.clientLogin.userid;
 
-            // changes browser url without additional redirect
-            history.replaceState("", "", location.href.split("?")[0]);
             this.saveCookies();
             this.login();
         } else {


### PR DESCRIPTION
There was race condition between 2 asynchronous tasks, where both changed url, and then it happened, that once there was `?authcode=...` and second time there wasn't -> this had convequence when parsing name...