### PR TITLE
Improve handling of preferred name and nicknames in PersonName

### DIFF
--- a/person_name.js
+++ b/person_name.js
@@ -196,13 +196,13 @@ class PersonName {
 
     /**
      * Construct a name with the given composition for this person.
-     * @param {*} wantedParts The parts of the name to be used in the construction of the name.
+     * @param {*} wantedParts An array listing the parts of the name to be used in the construction of the name.
      *    Possible part values are below. Note that the part value names do not always correspond with the API
      *    field name. Only the parts marked with (*) map directly to a single API field and will be used unadultered.
      *    If a part is part of other parts specified in wantedParts, it will be ignored.
      *    If a part is a combination of other parts in wantedParts, those other parts will be ignored.
      *    The order of the parts in the list is not important since their order in the name construction
-     *    is predetermined (for now - this might have to change).
+     *    is predetermined (as per the order of the pars in PedigreeName).
      *       * PedigreeName - 'Prefix FirstName MiddleNames (PreferredName) "Nicknames" (LastNameAtBirth) LastNameCurrent Suffix aka LastNameOther'.
      *       * FullName - 'Prefix FirstName MiddleNames (LastNameAtBirth) LastNameCurrent Suffix'.
      *       * LastName - LastNameCurrent if it exists, else LastNameAtBirth;
@@ -220,7 +220,7 @@ class PersonName {
      *       * Nicknames(*) - the Nicknames API field
      *       * Prefix(*) - the Prefix API field
      *       * Suffix(*) - the Suffix API field
-     * @returns a name constructed as requested. If a part is specified, but it, or its constituent parts are not
+     * @returns a name constructed as requested. If a part is specified, but it or its constituent parts are not
      * present in the profile, it will be ignored.
      */
     withParts(wantedParts) {
@@ -229,6 +229,33 @@ class PersonName {
             return `Invalid name part(s) ${invalidParts} requested`;
         }
         const [partsWanted, fieldsNeeded] = PersonName.#getWantsAndNeeds(wantedParts, true);
+
+        // Ensure PreferredName is in brackets if first name is present
+        const firstNameIsPresent =
+            (fieldsNeeded.has("firstName") && this.firstName) ||
+            (fieldsNeeded.has("firstNames") && this.firstNames) ||
+            (fieldsNeeded.has("fullFirstName") && this.fullFirstName);
+        let preferredName = this.preferredName;
+        if (
+            firstNameIsPresent &&
+            fieldsNeeded.has("preferredName") &&
+            !fieldsNeeded.has("bracketedPreferredName") &&
+            this.bracketedPreferredName &&
+            this.firstNames.includes(this.preferredName)
+        ) {
+            preferredName = this.bracketedPreferredName;
+        }
+
+        // Ensure Nicknames is in brackets if first name is present
+        let nicknames = this.nicknames;
+        if (
+            (firstNameIsPresent || (fieldsNeeded.has("preferredName") && preferredName)) &&
+            nicknames &&
+            fieldsNeeded.has("nicknames") &&
+            !fieldsNeeded.has("quotedNicknames")
+        ) {
+            nicknames = `"${nicknames}"`;
+        }
 
         const parts = [
             fieldsNeeded.has("prefix") ? this.prefix || null : null,
@@ -239,12 +266,10 @@ class PersonName {
             fieldsNeeded.has("middleInitials") ? this.middleInitials || null : null,
             fieldsNeeded.has("middleName") ? this.middleName || null : null,
             fieldsNeeded.has("middleNames") ? this.middleNames || null : null,
-            fieldsNeeded.has("preferredName") ? this.preferredName || null : null,
+            fieldsNeeded.has("preferredName") ? preferredName || null : null,
             fieldsNeeded.has("bracketedPreferredName") ? this.bracketedPreferredName || null : null,
-            fieldsNeeded.has("nicknames") && this.nicknames ? `<span class="nickname">${this.nicknames}</span>` : null,
-            fieldsNeeded.has("quotedNicknames") && this.nicknames
-                ? `<span class="nickname">"${this.nicknames}"</span>`
-                : null,
+            fieldsNeeded.has("nicknames") && nicknames ? `<span class="nickname">${nicknames}</span>` : null,
+            fieldsNeeded.has("quotedNicknames") && nicknames ? `<span class="nickname">"${nicknames}"</span>` : null,
             this.#formSurname(partsWanted),
             fieldsNeeded.has("suffix") ? this.suffix || null : null,
             fieldsNeeded.has("otherLastNames") ? this.otherLastNames || null : null,
@@ -346,10 +371,10 @@ class PersonName {
 
     /**
      * The best results will be obtained if the following set of fields are requested in the API call
-     * when obtaining the profile data (personData). These are the requested fields, not all these fields
-     * will necessarily be in the data returned from the API, but that should be OK.
-     *   Id, Name, FirstName, LastNameCurrent, LastNameAtBirth, LastNameOther, Suffix, Prefix, Derived.BirthName,
-     *   Derived.BirthNamePrivate, MiddleName, MiddleInitial, RealName, Nicknames
+     * when obtaining the profile data (personData). Not all these fields will necessarily be in the data
+     * returned from the API, but that should be OK.
+     *   FirstName, LastNameAtBirth, LastNameCurrent, LastNameOther, MiddleName, Nicknames, Prefix, RealName,
+     *   Suffix, Derived.BirthName, Derived.BirthNamePrivate
      * @param {*} personData The JSON data obtained for a profile via the WikiTree API
      */
     constructor(personData) {
@@ -388,7 +413,7 @@ class PersonName {
             );
             nameToSplit = (personData.FirstName || "") + " " + (personData.MiddleName || "");
             if (nameToSplit == " ") {
-                nameToSplit = personData.preferredName || personData.RealName || "";
+                nameToSplit = personData.RealName || "";
             }
         }
 

--- a/views/nameTest/name_test.js
+++ b/views/nameTest/name_test.js
@@ -1,63 +1,145 @@
 window.NameTestView = class NameTestView extends View {
+    static #RECOMMENDED_FIELDS =
+        "FirstName,LastNameAtBirth,LastNameCurrent,LastNameOther,MiddleName,Nicknames,Prefix,RealName,Suffix," +
+        "Derived.BirthName,Derived.BirthNamePrivate";
+    static #DESCRIPTION =
+        "<p>This page is used to test the PersonName class available in the " +
+        '<a href="https://github.com/wikitree/wikitree-dynamic-tree/blob/main/person_name.js"> WikiTree Dynamic Tree code</a>. ' +
+        "A PersonName object is created from profile data obtained via an API call. " +
+        "For the best results it is recommended that the following name fields always be requested in the API call:" +
+        `<blockquote>${NameTestView.#RECOMMENDED_FIELDS}</blockquote>` +
+        "<p>Two functions are then available on the object " +
+        "with which to construct a name from profile data:<br>" +
+        "&nbsp;&nbsp;&nbsp;&nbsp;<b>.withParts(wantedParts)</b> that constructs a name with the requested parts, and<br>" +
+        "&nbsp;&nbsp;&nbsp;&nbsp;<b>.getParts(wantedParts)</b> that returns the requested name parts as a map.<br>" +
+        "<i>wantedParts</i> is an array of the names (strings) of the parts to be used in the construction of the " +
+        "name. Possible part values are below. Only the parts marked with (*) map directly to a " +
+        "single API field and will be used unadultered. " +
+        "In <b>.withParts</b>: if a part is part of other parts specified in <i>wantedParts</i>, it will be ignored. " +
+        "Or put differently, if it is a combination of other parts in <i>wantedParts</i>, those other parts will be ignored. " +
+        "The order of the parts in the list is not important since their order in the name construction for " +
+        "<b>.withParts</b> is predetermined.</p>" +
+        '<ul><li>PedigreeName - Prefix FirstName MiddleNames (PreferredName) "Nicknames" (LastNameAtBirth) LastNameCurrent Suffix aka LastNameOther</br>' +
+        "<li>FullName - Prefix FirstName MiddleNames (LastNameAtBirth) LastNameCurrent Suffix.</br>" +
+        "<li>LastName - LastNameCurrent if it exists, else LastNameAtBirth;</br>" +
+        "<li>LastNameCurrent - if present and different from LastNameAtBirth, otherwise LastNameAtBirth</br>" +
+        "<li>LastNameAtBirth - if present and different from LastNameCurrent, otherwise LastNameCurrent</br>" +
+        "<li>LastNameOther(*) - the LastNameOther API field</br>" +
+        "<li>FirstName - the first name in the FirstName API field if present, otherwise the first name in BirthNamePrivate</br>" +
+        "<li>FirstNames - FirstName plus MiddleNames</br>" +
+        "<li>FullFirstName(*) - the FirstName API field</br>" +
+        "<li>PreferredName - the first name in the RealName API field if present, else the first name in the FirstName API field</br>" +
+        "<li>FirstInitial - The first letter, capitalised, of FirstName above</br>" +
+        "<li>MiddleName(*) - the MiddleName API field</br>" +
+        "<li>MiddleNames - all names other than any last name and the first name in FirstName</br>" +
+        "<li>MiddleInitials - The first letters, capitalised, space separated, of MiddleNames</br>" +
+        "<li>Nicknames(*) - the Nicknames API field</br>" +
+        "<li>Prefix(*) - the Prefix API field</br>" +
+        "<li>Suffix(*) - the Suffix API field</br></ul>" +
+        "<p>A third function is:<br>" +
+        "&nbsp;&nbsp;&nbsp;&nbsp;<b>.withFormat(template)</b> that returns a string constructed according to <i>template</i>, " +
+        'where <i>template</i> is a string with placeholders, e.g.: "He is [FullName], better known as [PreferredName], but ' +
+        'also as [Nicknames]."<br>' +
+        "<p>This page shows the result of calling the above functions with the indicated name parts parameter for the person " +
+        "specified above, as well as a few calls to <b>.withFormat</b>. This is repeated for the same profile obtained with " +
+        "different combinations of requested fields in the API</p>" +
+        "<p>But first it allows you to experiment with name construction for this person by supplying your own list of wanted parts.</p>";
+
     meta() {
         return {
             title: "Test name construction",
-            description:
-                "<p>A ProfileName object is created from profile data. Two functions are then available on the object " +
-                "with which to construct a name from profile data:<br>" +
-                "&nbsp;&nbsp;&nbsp;&nbsp;<b>.withParts(wantedParts)</b> that constructs a name with the requested parts, and<br>" +
-                "&nbsp;&nbsp;&nbsp;&nbsp;<b>.getParts(wantedParts)</b> that returns the requested name parts as a map.<br>" +
-                "<i>wantedParts</i> is an array of the names (strings) of the parts to be used in the construction of the " +
-                "name. Possible part values are below. Only the parts marked with (*) map directly to a " +
-                "single API field and will be used unadultered. " +
-                "In <b>.withParts</b>: if a part is part of other parts specified in <i>wantedParts</i>, it will be ignored. " +
-                "Or put differently, if it is a combination of other parts in <i>wantedParts</i>, those other parts will be ignored. " +
-                "The order of the parts in the list is not important since their order in the name construction for " +
-                "<b>.withParts</b> is predetermined.</p>" +
-                '<ul><li>PedigreeName - Prefix FirstName MiddleNames (PreferredName) "Nicknames" (LastNameAtBirth) LastNameCurrent Suffix aka LastNameOther</br>' +
-                "<font color=red>Question: Should PreferredName perhaps only be present if it differs from FirstName?</font><br>" +
-                "<li>FullName - Prefix FirstName MiddleNames (LastNameAtBirth) LastNameCurrent Suffix.</br>" +
-                "<li>LastName - LastNameCurrent if it exists, else LastNameAtBirth;</br>" +
-                "<li>LastNameCurrent - if present and different from LastNameAtBirth, otherwise LastNameAtBirth</br>" +
-                "<li>LastNameAtBirth - if present and different from LastNameCurrent, otherwise LastNameCurrent</br>" +
-                "<li>LastNameOther(*) - the LastNameOther API field</br>" +
-                "<li>FirstName - the first name in the FirstName API field if present, otherwise the first name in BirthNamePrivate</br>" +
-                "<li>FirstNames - FirstName plus MiddleNames</br>" +
-                "<li>FullFirstName(*) - the FirstName API field</br>" +
-                "<li>PreferredName - the first name in the RealName API field if present, else the first name in the FirstName API field</br>" +
-                "<li>FirstInitial - The first letter, capitalised, of FirstName above</br>" +
-                "<li>MiddleName(*) - the MiddleName API field</br>" +
-                "<li>MiddleNames - all names other than any last name and the first name in FirstName</br>" +
-                "<li>MiddleInitials - The first letters, capitalised, space separated, of MiddleNames</br>" +
-                "<li>Nicknames(*) - the Nicknames API field</br>" +
-                "<li>Prefix(*) - the Prefix API field</br>" +
-                "<li>Suffix(*) - the Suffix API field</br></ul>" +
-                "<p>A third function is:<br>" +
-                "&nbsp;&nbsp;&nbsp;&nbsp;<b>.withFormat(template)</b> that returns a string constructed according to <i>template</i>, " +
-                'where <i>template</i> is a string with placeholders, e.g.: "He is [FullName], better known as [PreferredName], but ' +
-                'also as [Nicknames]."<br>' +
-                "<p>This page shows the result of calling the above functions with the indicated name parts parameter for the person " +
-                "specified above, as well as a few calls to <b>.withFormat</b>. This is repeated for the same profile obtained with " +
-                "different combinations of requested fields in the API",
+            description: NameTestView.#DESCRIPTION,
             docs: "",
             disabled: 1,
         };
     }
 
-    init(container_selector, person_id) {
+    async init(container_selector, person_id) {
+        wtViewRegistry.setInfoPanel(NameTestView.#DESCRIPTION);
+        wtViewRegistry.showInfoPanel();
         const nameTest = new NameTest(container_selector, person_id);
-        nameTest.displayNames(
-            "Id,Name,FirstName,LastNameCurrent,LastNameAtBirth,LastNameOther,Suffix,Prefix,Derived.BirthName," +
-                "Derived.BirthNamePrivate,MiddleName,MiddleInitial,RealName,Nicknames"
-        );
-        nameTest.displayNames("Name,Id,LastNameAtBirth,FirstName,MiddleName,LastNameCurrent");
+        window.nameTest = nameTest;
+        nameTest
+            .displayNames("Name,Id,LastNameAtBirth,FirstName,MiddleName,LastNameCurrent")
+            .then(nameTest.displayNames("Id,Name," + NameTestView.#RECOMMENDED_FIELDS));
     }
 };
 
+window.nameTest = null;
+
 window.NameTest = class NameTest {
+    // 2 Cookie names
+    C_WT_PROFILE_FIELDS = "WikiTree_NameTest_fields";
+    C_WT_WANTED_PARTS = "WikiTree_NameTest_parts";
+    userSuppliedProfileFields;
+    lastProfileFieldsRetrieved;
+    lastWantedPartsUsed;
+    lastNameObjectUsed;
+
     constructor(selector, startId) {
         this.startId = startId;
-        $(selector).html(`<div id="nameTestResults"></div>`);
+        this.loadCookies();
+        $(selector).html(`<div id="doitself">
+        <h2>Self Test</h2>
+            <blockquote>
+            <form name="fieldForm" action="" method="GET">
+            Enter the comma-delimeted field names to retrieve via the API and click the button.<br>
+            <input type="text" id="profileFields" name="inputbox" size=100 value="">
+            <input type="button" name="button" class=small value="Retrieve via API and run Test" onClick="window.nameTest.getProfileWithFields(this.form)">
+            </form>
+            <form name="wantedForm" action="" method="GET">
+            Enter the comma-delimeted name parts you want below and click the button to see the result for <b>.withParts</b>: <br>
+            <input type="text" id="wantedParts" name="inputbox" size=100 value="">
+            <input type="button" name="button" class=small value="Construct Name" onClick="window.nameTest.getNameWithNameParts(this.form)">
+            </form>
+            <p>Profile fields retrieved: <span id=theFields></span></p>
+            <p>Name constructed <b>withParts</b>: <span id=theParts>(fill in above and click the botton)</span>:</p>
+            <ul><li id="userWithParts"></li></ul>
+            <p>Parts returned with <b>getParts</b> using the same part names as above:
+            <ul><li id="userGetParts"></li></ul>
+        </blockquote>
+        </div>
+        <h2 id="resultHeading">Built-in Test Results</h2>
+        <div id="nameTestResults"></div>`);
+        document.getElementById("profileFields").defaultValue = this.userSuppliedProfileFields || "";
+        document.getElementById("wantedParts").defaultValue = this.lastWantedPartsUsed || "";
+    }
+
+    loadCookies() {
+        this.userSuppliedProfileFields = WikiTreeAPI.cookie(this.C_WT_PROFILE_FIELDS) || "";
+        this.lastWantedPartsUsed = WikiTreeAPI.cookie(this.C_WT_WANTED_PARTS) || "";
+    }
+
+    saveCookies() {
+        WikiTreeAPI.cookie(this.C_WT_PROFILE_FIELDS, this.userSuppliedProfileFields, { path: "/" });
+        WikiTreeAPI.cookie(this.C_WT_WANTED_PARTS, this.lastWantedPartsUsed, { path: "/" });
+    }
+
+    getProfileWithFields(form) {
+        const input = this.stripSpacesAndQuotes(form.inputbox.value);
+        this.userSuppliedProfileFields = input;
+        document.getElementById("profileFields").defaultValue = input;
+        this.saveCookies();
+        $("#resultHeading").html("Self Test Result");
+        $("#nameTestResults").html("");
+        this.displayNames(input);
+    }
+
+    getNameWithNameParts(form) {
+        const input = this.stripSpacesAndQuotes(form.inputbox.value);
+        const wanted = input.split(",");
+        this.lastWantedPartsUsed = input;
+        document.getElementById("wantedParts").defaultValue = input;
+        this.saveCookies();
+        $("#theParts").html(wanted.join(", "));
+        $("#userWithParts").html(this.lastNameObjectUsed.withParts(wanted));
+        const parts = this.lastNameObjectUsed.getParts(wanted);
+        $("#userGetParts").html(`${typeof parts === "string" ? parts : JSON.stringify([...parts])}`);
+    }
+
+    stripSpacesAndQuotes(str) {
+        const re = /[\s"']+/g;
+        return str.replaceAll(re, "");
     }
 
     async displayNames(profileFields) {
@@ -66,13 +148,16 @@ window.NameTest = class NameTest {
             key: this.startId,
             fields: profileFields,
         });
-        $("#nameTestResults").append(`<h3>Requested fields:</h3>\n<p>${profileFields}</p>`);
+        this.lastProfileFieldsRetrieved = profileFields;
+        $("#theFields").html(profileFields.split(",").join(", "));
+        $("#nameTestResults").append(`<h3>Requested fields:</h3>\n<blockquote>${profileFields}</blockquote>`);
         if (data.length != 1) {
             wtViewRegistry.showError(`There was an error retrieving the profile for ${this.startId}.`);
             return;
         }
         const profileData = data[0].person;
         const name = new PersonName(profileData);
+        this.lastNameObjectUsed = name;
         const partsTestResults = new Array(
             this.doPartsTest(name, ["PedigreeName"]),
             this.doPartsTest(name, [
@@ -132,7 +217,7 @@ window.NameTest = class NameTest {
                 name,
                 "This is an invalid [Placeholder], but this is fine: [FirstInitial] [MiddleInitials]"
             ),
-            this.doFormatTest(name, "Prefix='[Prefix]', [LastName], [FirstName] ([MiddleNames]) Suffux=[[Suffix]]")
+            this.doFormatTest(name, "Prefix='[Prefix]', [LastName], [FirstName] ([MiddleNames]) Suffix=[[Suffix]]")
         );
         this.displayFormatResults(formatTestResults);
     }
@@ -154,7 +239,9 @@ window.NameTest = class NameTest {
 
     displayPartsResults(profileData, partsTestResults) {
         $("#nameTestResults").append("<h3>Profile data:</h3>\n");
-        $("#nameTestResults").append(`<pre>${JSON.stringify(profileData, undefined, 4)}</pre>`);
+        $("#nameTestResults").append(
+            `<blockquote><pre>${JSON.stringify(profileData, undefined, 4)}</pre></blockquote>`
+        );
         $("#nameTestResults").append("<h3>Test Results</h3>");
         $("#nameTestResults").append("<h4>.withParts</b> and .getParts</h4>");
         let html = "<ol>";
@@ -186,6 +273,7 @@ window.NameTest = class NameTest {
         html += "</ol>";
         $("#nameTestResults").append(html);
     }
+
     displayFormatResult(formatTestResult) {
         return (
             `<li class="testResult"><b>Template</b>: ${formatTestResult.template}<br>\n` +


### PR DESCRIPTION
These names are now in parentheses and quotes (as in PedigreeName) if they are requested in the presence of other names. This change also provides a self-test/experimentation option on the Name Test view as can be seen at:
  https://apps.wikitree.com/apps/smit641/PersonNameTest/#view=nameTest