### PR TITLE
Add pop-up help text to the couples view

### DIFF
--- a/views/couplesTree/cache_loader.js
+++ b/views/couplesTree/cache_loader.js
@@ -18,6 +18,7 @@ export class CacheLoader {
         "Gender",
         "Mother",
         "Father",
+        "HasChildren",
         "DataStatus",
         "Photo",
     ];

--- a/views/couplesTree/cached_person.js
+++ b/views/couplesTree/cached_person.js
@@ -70,7 +70,7 @@ export class CachedPerson {
                 this.setSpouses(value);
             } else if (["Parents", "Children", "Siblings"].includes(key)) {
                 // Just set the IDs in the field and ensure each person is created and put in the cache
-                // We don't really need a Parents field since we have Mother and Father, but if we do add
+                // We don't really need a Parents field since we have Mother and Father, but we do add
                 // it because it is useful to determine if a profile's parents have been loaded and is
                 // being used to control how much of an ancestor tree should be drawn
                 const ids = Object.keys(value);
@@ -292,6 +292,9 @@ export class CachedPerson {
     }
     hasAParent() {
         return this.getFatherId() || this.getMotherId();
+    }
+    hasAChild() {
+        return this._data.HasChildren || this._data.Children?.length > 0;
     }
     isMale() {
         return this.getGender() == "Male";

--- a/views/couplesTree/couples_tree.css
+++ b/views/couplesTree/couples_tree.css
@@ -2,6 +2,11 @@
   --content-padding: 0;
 }
 
+#couples-view-container {
+  position: relative;
+  cursor: grab;
+}
+
 h4 {
   font-size: 14px;
 }
@@ -147,4 +152,46 @@ h4 {
 
 .minus:hover {
   stroke: #fcbb71;
+}
+
+#ct-help-button {
+  background: #393a3c;
+  color: #fff;
+  font-size: 0.8em;
+  padding: 0.1em 0.5em;
+  border-radius: 50%;
+  float: right;
+  font-weight: bold;
+  cursor: pointer;
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  z-index: 11000;
+}
+
+xx {
+  position: absolute;
+  top: 0.2em;
+  right: 0.6em;
+  font-size: 1em;
+  cursor: pointer;
+  font-weight: bold;
+  color: red;
+}
+
+#ct-help-text {
+  display: none;
+  border: 3px solid forestgreen;
+  border-radius: 1em;
+  padding: 0.3em 1em;
+  margin: 1em auto;
+  position: absolute;
+  top: 20px;
+  right: 100px;
+  width: 45em;
+  background: white;
+  box-shadow: 1em 1em 1em grey;
+  padding-right: 4em;
+  z-index: 11000;
+  cursor: default;
 }

--- a/views/fanChart/SettingsOptions.js
+++ b/views/fanChart/SettingsOptions.js
@@ -6,7 +6,7 @@ Originally downloaded 14 October 2022.
 
 modified by Greg Clarke, October 2022
 
-Modifications were made to turn this into a Class that could be used in 
+Modifications were made to turn this into a Class that could be used in
 any View of the Dynamic Tree that requires a settings panel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -99,7 +99,9 @@ SettingsOptions.SettingsOptionsObject = class SettingsOptionsObject {
     createSettingsDIV(data) {
         let theDIVhtml =
             '<div id=settingsDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid darkgreen 4px; border-radius: 15px; padding: 15px;}">' +
-            '<span style="color:red; align:left"><A onclick="' + data.viewClassName + '.cancelSettings();">[ <B><font color=red>x</font></B> ]</A></span>' +
+            '<span style="color:red; position:absolute; top:0.2em; right:0.6em"><A onclick="' +
+            data.viewClassName +
+            '.cancelSettings();">[ <B><font color=red>x</font></B> ]</A></span>' +
             this.createULelements(data) +
             '<br />    <div align="center">      <div id="status"></div>      <button id="saveSettingsChanges" class="saveButton">Save changes (all tabs)</button>';
         ("</div>");
@@ -156,7 +158,7 @@ SettingsOptions.SettingsOptionsObject = class SettingsOptionsObject {
         // console.log("setActiveTab called: tabName is: " + tabName);
         // console.log("this:", this);
         // console.log("tabElements" , this.tabElements);
-        
+
         for (let tab in this.tabElements) {
             let tabElement = this.tabElements[tab];
             // console.log(tabElement);


### PR DESCRIPTION
This also includes the following changes:
* Move the [x] close button of the SettingsOptions class (used for
  a Settings pop-up in a number of views, e.g. FanChart) to the top
  right of the pop-up so that it is close to the "open" button and
  is therefore reachable on a small screen. This also makes it
  consistent with the help pop-up of the dynamic tree and the
  soon-to-be released CC7 table view.
* Fix a bug when attempting to expand the children of a couple with
  a NoSpouse member.
* Do not add an expand children subtree button to a node that does
  not have any children.

The above changes can be previewed at
  https://apps.wikitree.com/apps/smit641/dynamic-tree