### PR TITLE
Convert Ancestor Line Explorer to use GetPeople

### DIFF
--- a/WikiTreeAPI.js
+++ b/WikiTreeAPI.js
@@ -327,7 +327,7 @@ WikiTreeAPI.getAncestors = async function (appId, id, depth, fields) {
  * WARNING:  See note above about what you get if you don't use the .then() ....
  *
  * @param {*} appId An application id (any string). 'TA-' will be prepended to denotes it as a "Tree App"
- * @param {*} IDs can be a single string, with a single ID or a set of comma separated IDs. OR it can be an array of IDs
+ * @param {*} IDs An array of IDs
  * @param {*} fields an array of fields to return for each profile (same as for getPerson or getProfile)
  * @param {*} options an option object which can contain these key-value pairs
  *                    - bioFormat	Optional: "wiki", "html", or "both"
@@ -357,6 +357,42 @@ WikiTreeAPI.getRelatives = async function (appId, IDs, fields, options = {}) {
 
     const result = await WikiTreeAPI.postToAPI(getRelativesParameters);
     return result[0].items;
+};
+
+/**
+ * @param {*} appId An application id (any string). 'TA-' will be prepended to denotes it as a "Tree App"
+ * @param {*} ids is an array of IDs
+ * @param {*} fields an array of fields to return for each profile (same as for getPerson or getProfile)
+ * @param {*} options an option object which can contain these key-value pairs
+ *            - bioFormat	Optional: "wiki", "html", or "both"
+ *            - siblings	If 1, then get siblings of profiles, If 0 (default), do not get siblings
+ *            - ancestors	Number of generations of ancestors (parents) to return from the starting id(s). Default 0.
+ *            - descendents	If true, the siblings are returned
+ *            - nuclear     Number of generations of nuclear relatives (parents, children, siblings, spouses) to return from the starting id(s). Default 0.
+ *            - minGeneration Generation number to start at when gathering relatives
+ *            - limit       The maximum number of related profiles to return (default 1000)
+ *            - start       The starting number of the returned page of (limit) profiles (default 0)
+ *           See https://github.com/wikitree/wikitree-api/blob/main/getPeople.md for more detail
+ * @returns a Promise for the status, resultByKey and people JSON items in the returned API response
+ */
+WikiTreeAPI.getPeople = async function (appId, ids, fields, options = {}) {
+    let getPeopleParameters = {
+        appId: appId,
+        action: "getPeople",
+        keys: ids.join(","),
+        fields: fields.join(","),
+    };
+
+    // go through the options object, and add any of those options to the getPeopleParameters
+    for (const key in options) {
+        if (Object.hasOwnProperty.call(options, key)) {
+            const element = options[key];
+            getPeopleParameters[key] = element;
+        }
+    }
+
+    const result = await WikiTreeAPI.postToAPI(getPeopleParameters);
+    return [result[0].status, result[0].resultByKey, result[0].people];
 };
 
 /**

--- a/views/ancestorLines/ancestor_lines_explorer.js
+++ b/views/ancestorLines/ancestor_lines_explorer.js
@@ -134,7 +134,7 @@ export class AncestorLinesExplorer {
                 <input
                   id="otherWtIds"
                   type="text"
-                  placeholder="(Optional) Enter comma-seperated WikiTree IDs"
+                  placeholder="(Optional) Enter comma-separated WikiTree IDs"
                   size="110"
                   title="Identify people of interest that need to be highlighted in the tree" />
                 <table id="optionsTbl">

--- a/views/ancestorLines/ancestor_lines_explorer.js
+++ b/views/ancestorLines/ancestor_lines_explorer.js
@@ -11,6 +11,13 @@ export class AncestorLinesExplorer {
             generations to be retrieved, the maximum level of the tree might be at more than N generations if an ancestor
             appears at more than one generation (i.e. level in the tree).
         </p>
+        <p>
+            <em><b>Warning</b>: A "full" (or complete) ancesstor tree of 15 generations or higher (e.g. for Windsor-1)
+            WILL take a long time to retrieve and an even longer to draw (a 15 generation tree can contain 32768 people).
+            It may even crash your browser.
+            It is possible, however, to rerieve 20 generations of trees that are relatively sparse in the older
+            generations.</em>
+        </p>
         <ul>
             <li>
                 People that appear more than once in the tree are marked with a coloured square.
@@ -86,8 +93,8 @@ export class AncestorLinesExplorer {
         this.selector = selector;
         $(selector).html(`<div id="aleContainer" class="ale">
             <div id="controlBlock">
-              <label for="generation">Max Generations:</label
-              ><select id="generation" title="The number of generations to retrieve">
+              <label for="generation"  title="The number of generations to fetch from WikiTree">Max Generations:</label
+              ><select id="generation" title="The number of generations to fetch from WikiTree">
                 <option value="2">2</option>
                 <option value="3">3</option>
                 <option value="4">4</option>
@@ -117,25 +124,19 @@ export class AncestorLinesExplorer {
                 Save</button
               ><button id="loadButton" class="small button" title="Load a previously saved data file and draw its tree.">
                 Load a File</button
-              ><input id="fileInput" type="file" style="display: none" /><button
-                id="drawTreeButton"
-                class="small button"
-                title="Draw the tree, highlighting paths to the people of interest">
-                (Re-)Draw Tree
-              </button>
+              ><input id="fileInput" type="file" style="display: none" />
               <span id="help-button" title="About this">?</span>
               <div id="help-text">${AncestorLinesExplorer.#helpText}</div>
               <br />
-              <label for="otherWtIds">People of Interest:</label>
-              <input
-                id="otherWtIds"
-                type="text"
-                placeholder="(Optional) Enter comma-seperated WikiTree IDs"
-                size="110"
-                title="Identify people of interest that need to be highlighted in the tree" />
-              <br />
               <fieldset>
                 <legend id="aleOptions" title="Click to Close/Open the options">Options:</legend>
+                <label for="otherWtIds">People of Interest:</label>
+                <input
+                  id="otherWtIds"
+                  type="text"
+                  placeholder="(Optional) Enter comma-seperated WikiTree IDs"
+                  size="110"
+                  title="Identify people of interest that need to be highlighted in the tree" />
                 <table id="optionsTbl">
                   <tr>
                     <td>
@@ -186,6 +187,14 @@ export class AncestorLinesExplorer {
                         step="10"
                         title="Determines the horizontal distance between generations." />
                     </td>
+                    <td align="right">
+                      <button
+                        id="drawTreeButton"
+                        class="small button"
+                        title="Draw the tree, highlighting paths to the people of interest">
+                        (Re-)Draw Tree
+                      </button>
+                    </rd>
                   </tr>
                   <tr>
                     <td>
@@ -231,30 +240,15 @@ export class AncestorLinesExplorer {
                       <input id="tHFactor" type="number" min="1" value="34" title="Determines the display height of the tree." />
                     </td>
                     <td>
-                      <label for="maxLevel" title="The level up to which to draw the full tree (0 for all)." class="left">
-                        Show tree to level:</label
-                      ><select id="maxLevel" title="The level up to which to draw the full tree (0 for all).">
+                      <label for="maxLevel" title="The tree will be drawn with only this number of generations (0 for all)." class="left">
+                        Limit display to generation:</label
+                      ><select id="maxLevel" title="The tree will be drawn with only this number of generations (0 for all).">
                         <option value="0">0</option>
                         <option value="1">1</option>
                         <option value="2">2</option>
                         <option value="3">3</option>
                         <option value="4">4</option>
-                        <option value="5">5</option>
-                        <option value="6">6</option>
-                        <option value="7">7</option>
-                        <option value="8" selected>8</option>
-                        <option value="9">9</option>
-                        <option value="10">10</option>
-                        <option value="11">11</option>
-                        <option value="12">12</option>
-                        <option value="13">13</option>
-                        <option value="14">14</option>
-                        <option value="15">15</option>
-                        <option value="16">16</option>
-                        <option value="17">17</option>
-                        <option value="18">18</option>
-                        <option value="19">19</option>
-                        <option value="20">20</option>
+                        <option value="5" selected>5</option>
                       </select>
                     </td>
                   </tr>
@@ -290,7 +284,7 @@ export class AncestorLinesExplorer {
         $("#savePeople").click(function (e) {
             e.preventDefault();
             const fileName = AncestorLinesExplorer.makeFilename();
-            AncestorLinesExplorer.saveArrayToFile(Array.from(AncestorTree.getPeople()), fileName);
+            AncestorLinesExplorer.saveArrayToFile(AncestorTree.toArray(), fileName);
         });
         $("#loadButton").click(function (e) {
             e.preventDefault();
@@ -303,6 +297,7 @@ export class AncestorLinesExplorer {
         $("#aleBrickWallColour").on("change", function () {
             $("#drawTreeButton").click();
         });
+        AncestorLinesExplorer.updateMaxLevelSelection(20, 5);
 
         const container = $("#theSvg");
         container.draggable({ axis: "x" });
@@ -323,6 +318,14 @@ export class AncestorLinesExplorer {
             $(this).parent().slideUp();
         });
         $("#getAncestorsButton").click();
+    }
+
+    static updateMaxLevelSelection(maxLevel, selected) {
+        const select = document.getElementById("maxLevel");
+        select.options.length = 0;
+        for (let i = 0; i <= maxLevel; ++i) {
+            select.options[i] = new Option(`${i}`, i, i == 5, i == selected);
+        }
     }
 
     static setGetPeopleButtonText(n) {
@@ -353,6 +356,8 @@ export class AncestorLinesExplorer {
     }
 
     static findPathsAndDrawTree(event) {
+        const selectedMaxLevel = Math.min(document.getElementById("maxLevel").value, AncestorTree.maxGeneration);
+        AncestorLinesExplorer.updateMaxLevelSelection(AncestorTree.maxGeneration, selectedMaxLevel);
         if (event.shiftKey) {
             AncestorLinesExplorer.setEarlySaAfricaIndiaIds();
         }
@@ -390,9 +395,9 @@ export class AncestorLinesExplorer {
 
     static async retrieveAncestorsFromWT(wtId, nrGenerations) {
         const treeDepth = nrGenerations > 1 ? nrGenerations - 1 : 4;
-        const [theTreeRoot, buildTime] = await AncestorTree.buildTreeWithGetRelatives(wtId, treeDepth);
+        const [theTreeRoot, buildTime] = await AncestorTree.buildTreeWithGetPeople(wtId, treeDepth);
         // console.log("theTreeRoot", theTreeRoot);
-        // console.log(`Tree, size=${Tree.getPeople().size}, buildTime=${buildTime}ms`, Tree.getPeople());
+        console.log(`Tree size=${AncestorTree.getPeople().size}, buildTime=${buildTime}ms`);
         return theTreeRoot;
     }
 
@@ -450,8 +455,9 @@ export class AncestorLinesExplorer {
             AncestorTree.replaceWith(people);
             AncestorLinesExplorer.hideShakingTree();
             $(wtViewRegistry.WT_ID_TEXT).val(AncestorTree.root.getWtId());
-            $("#generation").val(AncestorTree.maxGeneration);
-            AncestorLinesExplorer.setGetPeopleButtonText(AncestorTree.maxGeneration);
+            const maxGen = Math.min(AncestorTree.maxGeneration, 20);
+            $("#generation").val(maxGen);
+            AncestorLinesExplorer.setGetPeopleButtonText(maxGen);
             AncestorLinesExplorer.findPathsAndDrawTree(event);
         };
 

--- a/views/ancestorLines/ancestor_tree.js
+++ b/views/ancestorLines/ancestor_tree.js
@@ -95,7 +95,7 @@ export class AncestorTree {
 
     static async makePagedCallAndAddPeople(reqIds, depth, start, limit) {
         console.log(`Calling getPeople with keys:${reqIds}, ancestors:${depth}, start:${start}, limit:${limit}`);
-        const [resultByKey, ancestor_json] = await API.getPeople([reqIds], depth, start, limit);
+        const [resultByKey, ancestor_json] = await API.getPeople(reqIds, depth, start, limit);
         let profiles = ancestor_json ? Object.values(ancestor_json) : [];
         console.log(`Received ${profiles.length} profiles`);
         const notLoaded = new Set();

--- a/views/ancestorLines/api.js
+++ b/views/ancestorLines/api.js
@@ -1,6 +1,7 @@
 export class API {
     static APP_ID = "AncestorLineExplorer";
-    static MAX_API_DEPTH = 8; // how many generations we are prepared to retrieve per API call
+    static MAX_API_DEPTH = 10; // how many generations we are prepared to retrieve per API call
+    static GET_PERSON_LIMIT = 1000;
     static PRIMARY_FIELDS = [
         "BirthDate",
         "BirthLocation",
@@ -21,7 +22,7 @@ export class API {
         "Mother",
         "Name",
         "Nicknames",
-        "Photo",
+        // "Photo",
         "Prefix",
         "RealName",
         "Suffix",
@@ -33,5 +34,17 @@ export class API {
 
     static async getRelatives(ids, fields = API.PRIMARY_FIELDS) {
         return WikiTreeAPI.getRelatives(API.APP_ID, ids, fields);
+    }
+
+    static async getPeople(ids, ancestors = 0, start = 0, limit = API.GET_PERSON_LIMIT, fields = API.PRIMARY_FIELDS) {
+        const [status, resultByKey, people] = await WikiTreeAPI.getPeople(API.APP_ID, ids, fields, {
+            ancestors: ancestors,
+            start: start,
+            limit: limit,
+        });
+        if (status != "") {
+            console.warn(`getpeople returned status: ${status}`);
+        }
+        return [resultByKey, people];
     }
 }

--- a/views/ancestorLines/display.js
+++ b/views/ancestorLines/display.js
@@ -128,7 +128,7 @@ export function showTree(
     const inTree = connectors ? new Set() : undefined;
     // Assigns parent, children, height, depth
     const root = d3.hierarchy(theRoot, function (d) {
-        return d.getD3Children(inTree);
+        return AncestorTree.getD3Children(d, inTree);
     });
     root.x0 = treeHeight / 2;
     root.y0 = 0;

--- a/views/ancestorLines/person.js
+++ b/views/ancestorLines/person.js
@@ -1,10 +1,4 @@
 export class Person {
-    static #people = new Map();
-
-    static init(map) {
-        Person.#people = map;
-    }
-
     constructor(data, fromFile = false) {
         let name = data.BirthName ? data.BirthName : data.BirthNamePrivate;
         if (fromFile) {
@@ -79,25 +73,6 @@ export class Person {
     getParentIds() {
         return [this._data.Father, this._data.Mother];
     }
-    getD3Children(alreadyInTree) {
-        const self = this;
-        const parents = [];
-        addParent(+this.getFatherId());
-        addParent(+this.getMotherId());
-        return parents;
-
-        function addParent(id) {
-            if (id && Person.#people.has(id)) {
-                const person = Person.#people.get(id);
-                if (alreadyInTree && alreadyInTree.has(id)) {
-                    parents.push(new LinkToPerson(person));
-                } else {
-                    if (alreadyInTree) alreadyInTree.add(id);
-                    parents.push(person);
-                }
-            }
-        }
-    }
     getDisplayName() {
         return this._data.BirthName ? this._data.BirthName : this._data.BirthNamePrivate;
     }
@@ -157,20 +132,8 @@ export class Person {
             return self._data.isDiedYoung;
         }
     }
-    hasFields(mustHaveFields) {
-        let hasAll = true;
-        for (const i in mustHaveFields || []) {
-            hasAll &&= Object.hasOwn(this._data, mustHaveFields[i]);
-        }
-        return hasAll;
-    }
-
     isDeadEnd() {
         return !this.hasAParent();
-    }
-
-    size() {
-        return this.#people.size;
     }
 
     toString() {
@@ -178,7 +141,7 @@ export class Person {
     }
 }
 
-class LinkToPerson extends Person {
+export class LinkToPerson extends Person {
     constructor(p) {
         super({
             Id: p.getId(),


### PR DESCRIPTION
This change includes the following improvements to the UI suggested by Chris Whitten in the G2g post
https://www.wikitree.com/g2g/1565385/yet-another-ancestor-tree-explorer?show=1591615#c1591615
* Move the "People of Interest" and "(Re-)Draw Tree" buttons inside the Options box.
* Change the "Show tree to level" to "Limit display to generation".
* The levels available in the "Limit display to generation" selection is adjusted to reflect the max number of generations available in the tree. 

An additional change removed the necessity to initialise the Person class with the map of people from the tree.

The new version can be tested at https://apps.wikitree.com/apps/smit641/dynamic-tree/#view=ale