### PR TITLE
minor CSS additions for printing

### DIFF
--- a/tree.css
+++ b/tree.css
@@ -387,6 +387,8 @@ main {
   }
 
   header,
+  #header,
+  #content,
   main {
     display: none;
   }


### PR DESCRIPTION
This fixes printing when hosted on WikiTree to prevent any header content from creating a blank first page.

It specifically ensures that the #header and #content DIV tags from WikiTree are hidden to make sure that only the #view-container DIV is included when printing.