### PR TITLE
Fix bug causing a false error to be displayed when switching views

### DIFF
--- a/tree.js
+++ b/tree.js
@@ -232,13 +232,15 @@ window.ViewRegistry = class ViewRegistry {
 
             this.clearStatus();
             if (this.currentView && this.currentView.id != view.id) {
-                try {
-                    this.currentView.close();
-                } catch (err) {
-                    this.showError(
-                        `An error occurred when closing the prvious view. You can ignore this, or please report it in G2G): ${err.message}`
-                    );
-                    this.hideInfoPanel();
+                if (typeof this.currentView.close === "function") {
+                    try {
+                        this.currentView.close();
+                    } catch (err) {
+                        this.showError(
+                            `An error occurred when closing the previous view. You can ignore this, or please report it in G2G): ${err.message}`
+                        );
+                        this.hideInfoPanel();
+                    }
                 }
             }
 

--- a/tree.js
+++ b/tree.js
@@ -237,7 +237,7 @@ window.ViewRegistry = class ViewRegistry {
                         this.currentView.close();
                     } catch (err) {
                         this.showError(
-                            `An error occurred when closing the previous view. You can ignore this, or please report it in G2G): ${err.message}`
+                            `An error occurred when closing the previous view (${this.currentView.id}). You can ignore this, or please report it in G2G): ${err.message}`
                         );
                         this.hideInfoPanel();
                     }

--- a/views/cc7/js/cc7.js
+++ b/views/cc7/js/cc7.js
@@ -161,6 +161,7 @@ export class CC7 {
         "Mother",
         "Name",
         "Nicknames",
+        "NoChildren",
         "Prefix",
         "Privacy",
         "RealName",
@@ -1799,7 +1800,7 @@ export class CC7 {
                         relNums[aR] = "";
                     }
                     relNums[aR + "_data"] = "data-" + aR + "='" + relNums[aR] + "'";
-                    let word;
+                    let word = aR + "s";
                     if (aR == "Child") {
                         word = "Children";
                         if (diedYoung && relNums[aR] == "") {
@@ -1808,8 +1809,13 @@ export class CC7 {
                         } else if (mPerson.NoChildren == 1) {
                             cellClass = "class='none number'";
                         }
-                    } else {
-                        word = aR + "s";
+                    } else if (
+                        aR == "Sibling" &&
+                        mPerson.Parent.length == 2 &&
+                        mPerson.Parent[0].NoChildren &&
+                        mPerson.Parent[0].NoChildren
+                    ) {
+                        cellClass = "class='none number'";
                     }
                     if (aR == "Spouse") {
                         if (mPerson.DataStatus?.Spouse == "blank" || (diedYoung && relNums[aR] == "")) {


### PR DESCRIPTION
Not all tree apps extend View, therefore having a no-op close() method in PR
https://github.com/wikitree/wikitree-dynamic-tree/commit/427e08405770373f34044e719c524c59189b326c was not good enough.

This fix can be tested at https://apps.wikitree.com/apps/smit641/test2/#name=Smit-641&view=wt-dynamic-tree

Previously going FROM any of the following views to any other view would trigger the error message "An error occurred when closing the prvious view. You can ignore this, or please report it in G2G): this.currentView.close is not a function":
fan chart
dynamic tree
fractal view
fanduko
web views
