### PR TITLE
CC7: Make fewer API calls by making use of the new Meta.Degrees

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
     <script type="module" src="views/couplesTree/cache_loader.js"></script>
     <script type="module" src="views/couplesTree/people_cache.js"></script>
     <script type="module" src="views/couplesTree/couples_tree.js"></script>
+    <link rel="stylesheet" href="views/ancestorLines/jquery.floatingscroll.css" />
     <link rel="stylesheet" href="views/couplesTree/couples_tree.css" />
 
     <script src="views/cc7/js/date.format.js"></script>

--- a/tree.js
+++ b/tree.js
@@ -256,7 +256,12 @@ window.ViewRegistry = class ViewRegistry {
         } else {
             infoPanel.classList.add("hidden");
             if (wtID) {
-                this.showError(`Person not found for WikiTree ID ${wtID}.`);
+                const status = data[0]["status"];
+                if (status == "Illegal WikiTree ID") {
+                    this.showError(`Person not found for WikiTree ID ${wtID}.`);
+                } else {
+                    this.showError(`An unexpected error occurred: ${status}. Refreshing the page might help.`);
+                }
             } else {
                 this.showError("Please enter a WikiTree ID.");
             }

--- a/views/cc7/cc7View.js
+++ b/views/cc7/cc7View.js
@@ -2,10 +2,7 @@ import { CC7 } from "./js/cc7.js";
 
 window.CC7View = class CC7View extends View {
     static #DESCRIPTION =
-        "Loading 7 degrees may take a while (it can be 2 minutes or more) so the default is set to 3. Feel free to change it. " +
-        "<b>Note</b>: degrees of separation might be shown as larger than actual if there are private profiles in the mix. " +
-        "These private profiles may also result in it not being possible to determine the degree of separation " +
-        "of some profiles, so the latter will be shown with a negative degree.";
+        "Loading 7 degrees may take a while (it can be 2 minutes or more) so the default is set to 3. Feel free to change it. ";
 
     constructor() {
         super();


### PR DESCRIPTION
We can now issue a single call to get all the degrees we want. Unfortunately we still need to get extra degrees (N+1 for CCN and N-1, N, and N+1 for degree N only) in order to calculate the relative counts correctly.

This change also includes:
* A change to tree.js that replaces the current "Person not found for WikiTree ID <id>" with "An unexpected error occurred: ${status}. Refreshing the page might help." whenever status is not "Illegal WikiTree ID". An end user might not know what the status really means (if it persists after a refresh), but at least they would be able to report it and someone might be able to help.
* re-instating the jquery.floatingscroll.css that was inadvertantly removed in the PR for the descendants app. How that failed to break things in production I don't know, but it certainly broke the test environment.