### PR TITLE
CC7: Add BioCheck information to the table

### DIFF
--- a/tree.js
+++ b/tree.js
@@ -53,6 +53,12 @@
  *
  */
 
+// BioCheck initialization - just once
+import("./lib/biocheck-api/src/BioCheckTemplateManager.js").then((bio) => {
+    window.bioCheckTemplateManager = new bio.BioCheckTemplateManager();
+    window.bioCheckTemplateManager.load();
+});
+
 window.View = class View {
     constructor() {
         this.id = null;

--- a/views/cc7/cc7View.js
+++ b/views/cc7/cc7View.js
@@ -1,8 +1,6 @@
 import { CC7 } from "./js/cc7.js";
 
 window.CC7View = class CC7View extends View {
-    static #DESCRIPTION =
-        "Loading 7 degrees may take a while (it can be 2 minutes or more) so the default is set to 3. Feel free to change it. ";
 
     constructor() {
         super();
@@ -12,7 +10,7 @@ window.CC7View = class CC7View extends View {
     meta() {
         return {
             title: "CC7 Views",
-            description: CC7View.#DESCRIPTION,
+            description: CC7.DESCRIPTION,
             docs: "",
         };
     }
@@ -25,8 +23,6 @@ window.CC7View = class CC7View extends View {
         if (!this.overflow) {
             this.overflow = $("#view-container").css("overflow");
         }
-        wtViewRegistry.setInfoPanel(CC7View.#DESCRIPTION);
-        wtViewRegistry.showInfoPanel();
         const cc7 = new CC7(container_selector, person_id);
     }
 

--- a/views/cc7/css/cc7.css
+++ b/views/cc7/css/cc7.css
@@ -40,6 +40,7 @@ img.privacyImage,
 img.timelineButton {
   height: 1em;
 }
+.cc7Table .bioIssue,
 img.familyHome,
 img.timelineButton {
   cursor: pointer;
@@ -53,6 +54,7 @@ div.cc7Table #tree {
   width: 5em;
   margin: auto;
 }
+.cc7Table .bioReport,
 .cc7Table .familySheet,
 .cc7Table .timeline {
   background: white;
@@ -66,6 +68,7 @@ div.cc7Table #tree {
   white-space: nowrap;
   z-index: 10000;
 }
+.bioReport.wrap,
 .timeline.wrap,
 .familySheet.wrap {
   width: 80%;
@@ -92,6 +95,7 @@ th.tlBioAge {
 .tlDate {
   white-space: nowrap;
 }
+.bioReport x,
 .timeline x,
 .familySheet x {
   position: absolute;
@@ -101,6 +105,7 @@ th.tlBioAge {
   cursor: pointer;
   color: red;
 }
+.bioReport w,
 .timeline w,
 .familySheet w {
   position: absolute;
@@ -120,6 +125,7 @@ div.cc7Table .timelineTable {
   width: 98%;
   margin: auto;
 }
+div.cc7Table .bioReportTable td,
 div.cc7Table .timelineTable td {
   border-top: none;
   border-bottom: none;
@@ -199,6 +205,13 @@ div.cc7Table .timelineTable td {
 }
 .cc7Table #peopleTable td.age-at-death {
   text-align: right;
+}
+.cc7Table #peopleTable td.bioIssue {
+  border: 2px solid red;
+}
+.cc7Table #peopleTable td.privBio {
+  text-align: center;
+  vertical-align: middle;
 }
 
 .cc7Table table#peopleTable {

--- a/views/cc7/js/cc7.js
+++ b/views/cc7/js/cc7.js
@@ -6,6 +6,10 @@
  * It makes use (through direct code inclusion) of FileSave (https://github.com/eligrey/FileSaver.js/)
  * and SheetJs (https://www.npmjs.com/package/xlsx)
  */
+import { theSourceRules } from "../../../lib/biocheck-api/src/SourceRules.js";
+import { BioCheckPerson } from "../../../lib/biocheck-api/src/BioCheckPerson.js";
+import { Biography } from "../../../lib/biocheck-api/src/Biography.js";
+
 export class CC7 {
     static APP_ID = "CC7";
     static SETTINGS_GEAR = "&#x2699;";
@@ -134,6 +138,7 @@ export class CC7 {
         </ul>`;
 
     static GET_PEOPLE_FIELDS = [
+        "Bio",
         "BirthDate",
         "BirthDateDecade",
         "BirthLocation",
@@ -151,6 +156,7 @@ export class CC7 {
         "Gender",
         "Id",
         "IsLiving",
+        "IsMember",
         "LastNameAtBirth",
         "LastNameCurrent",
         "LastNameOther",
@@ -543,52 +549,54 @@ export class CC7 {
             const wideTableButton = $("<button class='button small' id='wideTableButton'>Wide Table</button>");
             wideTableButton.insertBefore(pTable);
 
-            $("#wideTableButton").click(function (e) {
-                e.preventDefault();
+            $("#wideTableButton")
+                .off("click")
+                .on("click", function (e) {
+                    e.preventDefault();
 
-                const dTable = $(".peopleTable").eq(0);
-                if (CC7.getCookie("w_wideTable") == "1") {
-                    // Display a normal table
-                    CC7.setCookie("w_wideTable", 0, { expires: 365 });
-                    CC7.setOverflow("visible");
-                    dTable.removeClass("wide");
-                    $(this).text("Wide table");
-                    $("#peopleTable").attr("title", "");
-                    dTable.css({
-                        position: "relative",
-                        top: "0px",
-                        left: "0px",
-                    });
-                    dTable.draggable("disable");
-                } else {
-                    // Display a wide table
-                    CC7.setCookie("w_wideTable", 1, { expires: 365 });
-                    CC7.setOverflow("auto");
-                    $(this).text("Normal Table");
-                    $("#peopleTable").attr("title", "Drag to scroll left or right");
-                    dTable.addClass("wide");
-                    dTable.find("th").each(function () {
-                        $(this).data("width", $(this).css("width"));
-                        $(this).css("width", "auto");
-                    });
-                    var isiPad = navigator.userAgent.match(/iPad/i) != null;
-                    if (isiPad) {
-                        if ($("#cc7Container").length) {
-                            dTable.draggable({
-                                cursor: "grabbing",
-                            });
-                        }
+                    const dTable = $(".peopleTable").eq(0);
+                    if (CC7.getCookie("w_wideTable") == "1") {
+                        // Display a normal table
+                        CC7.setCookie("w_wideTable", 0, { expires: 365 });
+                        CC7.setOverflow("visible");
+                        dTable.removeClass("wide");
+                        $(this).text("Wide table");
+                        $("#peopleTable").attr("title", "");
+                        dTable.css({
+                            position: "relative",
+                            top: "0px",
+                            left: "0px",
+                        });
+                        dTable.draggable("disable");
                     } else {
-                        if ($("#cc7Container").length) {
-                            dTable.draggable({
-                                axis: "x",
-                                cursor: "grabbing",
-                            });
+                        // Display a wide table
+                        CC7.setCookie("w_wideTable", 1, { expires: 365 });
+                        CC7.setOverflow("auto");
+                        $(this).text("Normal Table");
+                        $("#peopleTable").attr("title", "Drag to scroll left or right");
+                        dTable.addClass("wide");
+                        dTable.find("th").each(function () {
+                            $(this).data("width", $(this).css("width"));
+                            $(this).css("width", "auto");
+                        });
+                        var isiPad = navigator.userAgent.match(/iPad/i) != null;
+                        if (isiPad) {
+                            if ($("#cc7Container").length) {
+                                dTable.draggable({
+                                    cursor: "grabbing",
+                                });
+                            }
+                        } else {
+                            if ($("#cc7Container").length) {
+                                dTable.draggable({
+                                    axis: "x",
+                                    cursor: "grabbing",
+                                });
+                            }
                         }
+                        dTable.draggable("enable");
                     }
-                    dTable.draggable("enable");
-                }
-            });
+                });
         }
         if (CC7.getCookie("w_wideTable") == "1") {
             CC7.setCookie("w_wideTable", 0, { expires: 365 });
@@ -1065,7 +1073,8 @@ export class CC7 {
     }
 
     static showTimeline(jqClicked) {
-        const id = +jqClicked.attr("data-id");
+        const theClickedRow = jqClicked.closest("tr");
+        const id = +theClickedRow.attr("data-id");
         let tPerson = window.people.get(id);
         const theClickedName = tPerson.Name;
         const familyId = theClickedName.replace(" ", "_") + "_timeLine";
@@ -1085,35 +1094,77 @@ export class CC7 {
         }
         // Make a table
         const timelineTable = CC7.buildTimeline(tPerson, familyFacts, familyId);
-        // Attach the table to the container div
-        timelineTable.prependTo($("#cc7Container"));
-        //timelineTable.css({ top: window.pointerY - 30, left: 10 });
-
         timelineTable.attr("id", familyId);
-        timelineTable.draggable();
-        timelineTable.dblclick(function () {
+        CC7.showTable(jqClicked, timelineTable, 30, 30);
+    }
+
+    static showTable(jqClicked, theTable, lOffset, tOffset) {
+        // Attach the table to the container div
+        theTable.prependTo($("#cc7Container"));
+        theTable.draggable();
+        theTable.off("dblclick").on("dblclick", function () {
             $(this).slideUp();
         });
 
-        CC7.setOffset(jqClicked, timelineTable, 75, 40);
+        CC7.setOffset(jqClicked, theTable, lOffset, tOffset);
         $(window).resize(function () {
-            if (timelineTable.length) {
-                CC7.setOffset(jqClicked, timelineTable, 75, 40);
+            if (theTable.length) {
+                CC7.setOffset(jqClicked, theTable, lOffset, tOffset);
             }
         });
 
-        timelineTable.slideDown("slow");
-        timelineTable.find("x").click(function () {
-            timelineTable.slideUp();
-        });
-        timelineTable.find("w").click(function () {
-            timelineTable.toggleClass("wrap");
-        });
+        theTable.slideDown("slow");
+        theTable
+            .find("x")
+            .off("click")
+            .on("click", function () {
+                theTable.slideUp();
+            });
+        theTable
+            .find("w")
+            .off("click")
+            .on("click", function () {
+                theTable.toggleClass("wrap");
+            });
     }
 
     static setOffset(theClicked, elem, lOffset, tOffset) {
         const theLeft = CC7.getOffset(theClicked[0]).left + lOffset;
         elem.css({ top: CC7.getOffset(theClicked[0]).top + tOffset, left: theLeft });
+    }
+
+    static showBioCheckReport(jqClicked) {
+        const theClickedRow = jqClicked.closest("tr");
+        const id = +theClickedRow.attr("data-id");
+        let person = window.people.get(id);
+        if (typeof person.bioCheckReport == "undefined" || person.bioCheckReport.length == 0) {
+            return;
+        }
+        const theClickedName = person.Name;
+        const familyId = theClickedName.replace(" ", "_") + "_bioCheck";
+        if ($(`#${familyId}`).length) {
+            $(`#${familyId}`).slideToggle();
+            return;
+        }
+
+        const bioReportTable = CC7.getBioCheckReportTable(person);
+        bioReportTable.attr("id", familyId);
+        CC7.showTable(jqClicked, bioReportTable, 30, 30);
+    }
+
+    static getBioCheckReportTable(person) {
+        const issueWord = person.bioCheckReport.length == 1 ? "issue" : "issues";
+        const bioCheckTable = $(
+            `<div class='bioReport' data-wtid='${person.Name}'><w>↔</w><x>[ x ]</x><table class="bioReportTable">` +
+                `<caption>Bio Check found the following ${issueWord} with the biography of ${person.FirstName}</caption>` +
+                "<tbody></tbody></table></div>"
+        );
+
+        for (const msg of person.bioCheckReport) {
+            const msgTR = $("<tr></tr>").append($("<td></td>").text(msg));
+            bioCheckTable.find("tbody").append(msgTR);
+        }
+        return bioCheckTable;
     }
 
     static peopleToTable(kPeople) {
@@ -1277,27 +1328,8 @@ export class CC7 {
         const thisFamily = [fPerson].concat(fPerson.Parent, fPerson.Sibling, fPerson.Spouse, fPerson.Child);
 
         const kkTable = CC7.peopleToTable(thisFamily);
-        kkTable.prependTo("#cc7Container");
         kkTable.attr("id", familyId);
-        kkTable.draggable();
-        kkTable.on("dblclick", function () {
-            $(this).slideUp();
-        });
-
-        CC7.setOffset(theClicked, kkTable, 0, 40);
-        $(window).resize(function () {
-            if (kkTable.length) {
-                CC7.setOffset(theClicked, kkTable, 0, 40);
-            }
-        });
-
-        kkTable.slideDown("slow");
-        kkTable.find("x").click(function () {
-            kkTable.slideUp();
-        });
-        kkTable.find("w").click(function () {
-            kkTable.toggleClass("wrap");
-        });
+        CC7.showTable(theClicked, kkTable, 30, 30);
     }
 
     static assignRelationshipsFor(person) {
@@ -1312,15 +1344,14 @@ export class CC7 {
         }
     }
 
-    static showFamilySheet(jq) {
-        const theClicked = jq;
-        const jqClosest = jq.closest("tr");
-        const theClickedName = jqClosest.attr("data-name");
-        const theClickedId = +jqClosest.attr("data-id");
+    static showFamilySheet(jqClicked) {
+        const theClickedRow = jqClicked.closest("tr");
+        const theClickedName = theClickedRow.attr("data-name");
+        const theClickedId = +theClickedRow.attr("data-id");
 
         const aPeo = window.people.get(theClickedId);
         if (aPeo?.Parent?.length > 0 || aPeo?.Child?.length > 0) {
-            CC7.doFamilySheet(aPeo, theClicked);
+            CC7.doFamilySheet(aPeo, jqClicked);
         } else {
             console.log(`Calling getRelatives for ${theClickedName}`);
             WikiTreeAPI.postToAPI({
@@ -1335,7 +1366,7 @@ export class CC7 {
                 // Construct this person so it conforms to the profiles retrieved using getPeople
                 const mPerson = CC7.convertToInternal(data[0].items[0].person);
                 window.people.set(+mPerson.Id, mPerson);
-                CC7.doFamilySheet(mPerson, theClicked);
+                CC7.doFamilySheet(mPerson, jqClicked);
             });
         }
     }
@@ -1629,7 +1660,7 @@ export class CC7 {
 
     static sortByThis(el) {
         const aTable = $("#peopleTable");
-        el.click(function () {
+        el.off("click").on("click", function () {
             let sorter = el.attr("id");
             let rows = aTable.find("tbody tr");
             if (sorter == "birthlocation" || sorter == "deathlocation") {
@@ -1724,7 +1755,7 @@ export class CC7 {
         const aTable = $(
             "<table id='peopleTable' class='peopleTable'>" +
                 aCaption +
-                "<thead><tr><th></th><th></th><th></th>" +
+                "<thead><tr><th title='Privacy/BioCheck'>P/B</th><th></th><th></th>" +
                 degreeTH +
                 parentsNum +
                 siblingsNum +
@@ -1814,7 +1845,7 @@ export class CC7 {
             switch (privacyLevel) {
                 case 60:
                     privacy = "./views/cc7/images/privacy_open.png";
-                    privacyTitle = "Open";
+                    privacyTitle = "Privacy: Open";
                     break;
                 case 50:
                     privacy = "./views/cc7/images/privacy_public.png";
@@ -2080,7 +2111,11 @@ export class CC7 {
                     dManager +
                     "' class='" +
                     gender +
-                    "'><td>" +
+                    `'><td ${
+                        mPerson.hasBioIssues
+                            ? "class='privBio bioIssue' title='Click to see Bio Check Report'"
+                            : "class='privBio'"
+                    }>` +
                     (privacy ? "<img class='privacyImage' src='" + privacy + "' title='" + privacyTitle + "'>" : "") +
                     `</td><td><img class='familyHome' src='./views/cc7/images/Home_icon.png' title="Click to see ${firstName}'s family sheet"></td>` +
                     `<td><img class='timelineButton' src='./views/cc7/images/timeline.png' title="Click to see a timeline for ${firstName}"></td>` +
@@ -2130,25 +2165,36 @@ export class CC7 {
             CC7.setOverflow("auto");
         }
         if ($("#cc7Container").length == 0) {
-            $(".peopleTable caption").click(function () {
-                $(this).parent().find("thead,tbody").slideToggle();
-            });
+            $(".peopleTable caption")
+                .off("click")
+                .on("click", function () {
+                    $(this).parent().find("thead,tbody").slideToggle();
+                });
         }
 
         // Provide a way to examine the data record of a specific person
-        $("img.privacyImage").click(function (event) {
-            if (event.altKey) {
+        $("img.privacyImage, .bioIssue")
+            .off("click")
+            .on("click", function (event) {
+                event.stopImmediatePropagation();
                 const id = $(this).closest("tr").attr("data-id");
                 const p = window.people.get(+id);
-                console.log(`${p.Name}, ${p.BirthNamePrivate}`, p);
-            }
-        });
-        $("img.familyHome").click(function () {
-            CC7.showFamilySheet($(this));
-        });
-        $("img.timelineButton").click(function (event) {
-            CC7.showTimeline($(this).closest("tr"));
-        });
+                if (event.altKey) {
+                    console.log(`${p.Name}, ${p.BirthNamePrivate}`, p);
+                } else if (p.hasBioIssues) {
+                    CC7.showBioCheckReport($(this));
+                }
+            });
+        $("img.familyHome")
+            .off("click")
+            .on("click", function () {
+                CC7.showFamilySheet($(this));
+            });
+        $("img.timelineButton")
+            .off("click")
+            .on("click", function (event) {
+                CC7.showTimeline($(this));
+            });
 
         aTable.find("th[id]").each(function () {
             CC7.sortByThis($(this));
@@ -2163,35 +2209,41 @@ export class CC7 {
                 )
             );
         }
-        $("#listViewButton").on("click", function () {
-            $(".viewButton").removeClass("active");
-            $(this).addClass("active");
-            $("#peopleTable,#hierarchyView").hide();
-            if ($("#lanceTable").length == 0) {
-                CC7.lanceView();
-            } else {
-                $("#lanceTable").show().addClass("active");
-                $("#wideTableButton").hide();
-            }
-        });
-        $("#hierarchyViewButton").on("click", function () {
-            $(".viewButton").removeClass("active");
-            $(this).addClass("active");
-            $("#peopleTable,#lanceTable").hide().removeClass("active");
-            if ($("#hierarchyView").length == 0) {
-                CC7.showShakingTree(() => CC7.hierarchyCC7());
-                $("#wideTableButton").hide();
-            } else {
-                $("#hierarchyView").show();
-            }
-        });
-        $("#tableViewButton").on("click", function () {
-            $(".viewButton").removeClass("active");
-            $(this).addClass("active");
-            $("#hierarchyView,#lanceTable").hide().removeClass("active");
-            $("#peopleTable").show();
-            $("#wideTableButton").show();
-        });
+        $("#listViewButton")
+            .off("click")
+            .on("click", function () {
+                $(".viewButton").removeClass("active");
+                $(this).addClass("active");
+                $("#peopleTable,#hierarchyView").hide();
+                if ($("#lanceTable").length == 0) {
+                    CC7.lanceView();
+                } else {
+                    $("#lanceTable").show().addClass("active");
+                    $("#wideTableButton").hide();
+                }
+            });
+        $("#hierarchyViewButton")
+            .off("click")
+            .on("click", function () {
+                $(".viewButton").removeClass("active");
+                $(this).addClass("active");
+                $("#peopleTable,#lanceTable").hide().removeClass("active");
+                if ($("#hierarchyView").length == 0) {
+                    CC7.showShakingTree(() => CC7.hierarchyCC7());
+                    $("#wideTableButton").hide();
+                } else {
+                    $("#hierarchyView").show();
+                }
+            });
+        $("#tableViewButton")
+            .off("click")
+            .on("click", function () {
+                $(".viewButton").removeClass("active");
+                $(this).addClass("active");
+                $("#hierarchyView,#lanceTable").hide().removeClass("active");
+                $("#peopleTable").show();
+                $("#wideTableButton").show();
+            });
 
         CC7.hideShakingTree();
         $("#countdown").fadeOut();
@@ -2209,17 +2261,21 @@ export class CC7 {
             $(
                 '<button id="cc7excel" title="Export an Excel file." class="small button" style="display: inline-block;">Excel</button>'
             ).insertAfter($("#loadButton"));
-            $("#cc7excel").click(function () {
-                CC7.cc7excelOut(CC7.EXCEL);
-            });
+            $("#cc7excel")
+                .off("click")
+                .on("click", function () {
+                    CC7.cc7excelOut(CC7.EXCEL);
+                });
         }
         if ($("#cc7csv").length == 0) {
             $(
                 '<button id="cc7csv" title="Export a CSV file." class="small button" style="display: inline-block;">CSV</button>'
             ).insertAfter($("#loadButton"));
-            $("#cc7csv").click(function () {
-                CC7.cc7excelOut(CC7.CSV);
-            });
+            $("#cc7csv")
+                .off("click")
+                .on("click", function () {
+                    CC7.cc7excelOut(CC7.CSV);
+                });
         }
         aTable.floatingScroll();
     }
@@ -2263,7 +2319,7 @@ export class CC7 {
             }
             const headerCellText = headerCell.textContent.trim();
             const originalHeaderCellText = originalHeaderCells[i].textContent.trim();
-            if (!["Pos."].includes(headerCellText) && !["Pos.", ""].includes(originalHeaderCellText)) {
+            if (!["Pos.", "P/B"].includes(headerCellText) && !["Pos.", "P/B", ""].includes(originalHeaderCellText)) {
                 // console.log(headerCellText);
                 filterCell.title = "Enter a column value to which to limit the rows";
                 const filterInput = document.createElement("input");
@@ -3187,6 +3243,7 @@ export class CC7 {
     }
 
     static addPeople(profiles, degreeCounts, minDegree, maxDegree) {
+        const userWTuserID = window.wtViewRegistry.session.lm.user.name;
         let nrAdded = 0;
         let maxDegreeFound = -1;
         for (const person of profiles) {
@@ -3217,6 +3274,45 @@ export class CC7 {
                 person.Sibling = [];
                 person.Child = [];
                 person.Marriage = {};
+
+                const bioPerson = new BioCheckPerson();
+                if (bioPerson.canUse(person, false, true, userWTuserID)) {
+                    const biography = new Biography(theSourceRules);
+                    biography.parse(bioPerson.getBio(), bioPerson, "");
+                    biography.validate();
+                    person.hasBioIssues = biography.hasStyleIssues() || !biography.hasSources();
+                    if (person.hasBioIssues) {
+                        person.bioCheckReport = getReportLines(biography, bioPerson.isPre1700());
+                    }
+                }
+                delete person.bio;
+
+                function getReportLines(biography, isPre1700) {
+                    const profileReportLines = [];
+                    if (!biography.hasSources()) {
+                        profileReportLines.push("Profile may be unsourced");
+                    }
+                    const invalidSources = biography.getInvalidSources();
+                    const nrInvalidSources = invalidSources.length;
+                    if (nrInvalidSources > 0) {
+                        let msg = "Bio Check found sources that are not ";
+                        if (isPre1700) {
+                            msg += "reliable or ";
+                        }
+                        msg += "clearly identified: \u00A0\u00A0";
+                        profileReportLines.push(msg);
+                        for (const invalidSource of invalidSources) {
+                            profileReportLines.push("\xa0\xa0\xa0" + invalidSource);
+                        }
+                    }
+                    for (const sectMsg of biography.getSectionMessages()) {
+                        profileReportLines.push(sectMsg);
+                    }
+                    for (const styleMsg of biography.getStyleMessages()) {
+                        profileReportLines.push(styleMsg);
+                    }
+                    return profileReportLines;
+                }
 
                 window.people.set(id, person);
                 ++nrAdded;

--- a/views/cc7/js/cc7.js
+++ b/views/cc7/js/cc7.js
@@ -14,7 +14,7 @@ export class CC7 {
     static APP_ID = "CC7";
     static DESCRIPTION =
         "Loading 7 degrees may take a while (it can be 2 minutes or more) so the default is set to 3. Feel free to change it. ";
-    static BIOCHECK_OFF_DESCRIPTION = CC7.DESCRIPTION + "Bio Check is OFF in settings.";
+    static BIOCHECK_OFF_DESCRIPTION = CC7.DESCRIPTION + "Bio Check is DISABLED in settings.";
     static SETTINGS_GEAR = "&#x2699;";
     static #helpText = `
         <x>[ x ]</x>
@@ -325,7 +325,7 @@ export class CC7 {
                 options: [
                     {
                         optionName: "bioComment",
-                        comment: "Turning this on will only affect the next load of profiles.",
+                        comment: "Enabling Bio Check only comes into effect at subsequent GET button clicks.",
                         type: "br",
                     },
                     {

--- a/views/fanChart/FanChartView.js
+++ b/views/fanChart/FanChartView.js
@@ -16,14 +16,9 @@
  * Some SVG button icons from SVG Repo - open-licencesed SVG Vector and Icons website:  https://www.svgrepo.com/
  */
 
-import { BioCheckTemplateManager } from "../../lib/biocheck-api/src/BioCheckTemplateManager.js";
 import { theSourceRules } from "../../lib/biocheck-api/src/SourceRules.js";
 import { BioCheckPerson } from "../../lib/biocheck-api/src/BioCheckPerson.js";
 import { Biography } from "../../lib/biocheck-api/src/Biography.js";
-
-// initialization - just once
-let bioCheckTemplateManager = new BioCheckTemplateManager();
-bioCheckTemplateManager.load();
 
 (function () {
     const APP_ID = "FanChart";
@@ -59,7 +54,7 @@ bioCheckTemplateManager.load();
     const AboutAdditionalProgrammers =
         "<A target=_blank href=https://www.wikitree.com/wiki/Duke-5773>Jonathan Duke</A>";
     const AboutAssistants = "Rob Pavey & Kay Knight";
-    const AboutLatestG2G =  "https://www.wikitree.com/g2g/1621138/fan-chart-update-august-2023-chocolate-peanut-butter"; // "https://www.wikitree.com/g2g/1599363/recent-updates-to-the-fan-chart-tree-app-july-2023";
+    const AboutLatestG2G = "https://www.wikitree.com/g2g/1621138/fan-chart-update-august-2023-chocolate-peanut-butter"; // "https://www.wikitree.com/g2g/1599363/recent-updates-to-the-fan-chart-tree-app-july-2023";
     const AboutHelpDoc = "https://www.wikitree.com/wiki/Space:Fan_Chart_app";
     const AboutOtherApps = "https://apps.wikitree.com/apps/clarke11007";
 
@@ -73,7 +68,7 @@ bioCheckTemplateManager.load();
     const SVGbtnUP =
         '<SVG width=18 height=14 ><polyline points="0,14 18,14 9,0 0,14" fill="red" stroke="red"/><polyline points="5,8 13,8" fill="none" stroke="white" stroke-width=2 /> <polyline points="9,3 9,13" fill="none" stroke="white" stroke-width=2 /> </SVG>';
 
-    const SVGbtnSETTINGS = `<svg height="16" width="16" version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+    const SVGbtnSETTINGS = `<svg height="16" width="16" version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
             viewBox="0 0 512 512"  xml:space="preserve">
         <style type="text/css">
             .st0{fill:#000000;}
@@ -99,7 +94,7 @@ bioCheckTemplateManager.load();
                 c0-46.184,37.458-83.622,83.622-83.622s83.602,37.438,83.602,83.622C339.612,302.179,302.174,339.618,256.01,339.618z"/>
         </g>
         </svg>`;
-    const SVGbtnINFO = `<svg fill="#0000FF" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+    const SVGbtnINFO = `<svg fill="#0000FF" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
             width="16" height="16" viewBox="0 0 45.818 45.818"
             xml:space="preserve">
         <g>
@@ -109,7 +104,7 @@ bioCheckTemplateManager.load();
                 c0-2.12,1.718-3.836,3.837-3.836c2.118,0,3.837,1.716,3.837,3.836C26.746,12.133,25.027,13.851,22.909,13.851z"/>
         </g>
         </svg>`;
-    const SVGbtnHELP = `<svg fill="#006600" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+    const SVGbtnHELP = `<svg fill="#006600" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
             width="16" height="16" viewBox="0 0 95.334 95.334"
             xml:space="preserve">
         <g>
@@ -124,8 +119,8 @@ bioCheckTemplateManager.load();
         </g>
         </svg>`;
 
-    const SVGbtnRESIZE2 = `<svg width="16" height="16" viewBox="0 -0.5 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            class="si-glyph si-glyph-arrow-fullscreen-2">    
+    const SVGbtnRESIZE2 = `<svg width="16" height="16" viewBox="0 -0.5 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+            class="si-glyph si-glyph-arrow-fullscreen-2">
             <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                 <path d="M14.988,6.979 C15.547,6.979 16,6.527 16,5.97 L16,1.008 C16,0.45 15.547,-0.000999999989 14.988,-0.000999999989 L10.011,-0.000999999989 C9.452,-0.000999999989 8.999,0.45 8.999,1.008 L10.579,2.583 L8.009,5.153 L5.439,2.583 L7.019,1.008 C7.019,0.45 6.566,-0.000999999989 6.007,-0.000999999989 L1.03,-0.000999999989 C0.471,-0.000999999989 0.0179999999,0.45 0.0179999999,1.008 L0.0179999999,5.97 C0.0179999999,6.527 0.471,6.979 1.03,6.979 L2.62,5.394 L5.194,7.968 L2.598,10.565 L1.028,9 C0.471,9 0.0189999999,9.45 0.0189999999,10.006 L0.0189999999,14.952 C0.0189999999,15.507 0.471,15.958 1.028,15.958 L5.99,15.958 C6.548,15.958 6.999,15.507 6.999,14.952 L5.417,13.375 L8.009,10.783 L10.601,13.375 L9.019,14.952 C9.019,15.507 9.47,15.958 10.028,15.958 L14.99,15.958 C15.547,15.958 15.999,15.507 15.999,14.952 L15.999,10.006 C15.999,9.45 15.547,9 14.99,9 L13.42,10.565 L10.824,7.968 L13.398,5.394 L14.988,6.979 L14.988,6.979 Z" fill="#434343" class="si-glyph-fill">
                 </path>
@@ -1224,13 +1219,10 @@ bioCheckTemplateManager.load();
         FanChartView.reZoom = function () {
             // condLog("TIME to RE ZOOM now !", FanChartView.currentScaleFactor);
             let newScaleFactor = 0.8;
-           
+
             let svg = document.getElementById("fanChartSVG");
             let makeFitZoomFactor = 1;
             // return;
-
-             
-
 
             if (svg) {
                 let g = svg.firstElementChild;
@@ -1245,8 +1237,9 @@ bioCheckTemplateManager.load();
                             `${boundingBox.x} ${boundingBox.y} ${boundingBox.width} ${boundingBox.height}`
                         );
 
-                        if (window.innerWidth * h / boundingBox.width > (window.innerHeight - 30)) {
-                            makeFitZoomFactor = (window.innerHeight - 30) / ((window.innerWidth * h) / boundingBox.width);
+                        if ((window.innerWidth * h) / boundingBox.width > window.innerHeight - 30) {
+                            makeFitZoomFactor =
+                                (window.innerHeight - 30) / ((window.innerWidth * h) / boundingBox.width);
                         }
                     }
                 }
@@ -1255,7 +1248,7 @@ bioCheckTemplateManager.load();
                 //     FanChartView.currentScaleFactor,
                 //     FanChartView.lastCustomScaleFactor,
                 //     0.8 * makeFitZoomFactor,
-                
+
                 // );
 
                 if (
@@ -1295,7 +1288,7 @@ bioCheckTemplateManager.load();
                 //     newScaleFactor  * window.innerWidth +
                 //         " x " +
                 //         newScaleFactor * window.innerHeight
-                // );    
+                // );
 
                 d3.select(svg).call(
                     FanChartView.zoom.transform,
@@ -1320,8 +1313,7 @@ bioCheckTemplateManager.load();
                 let showBadges = FanChartView.currentSettings["general_options_showBadges"];
                 let colourBy = FanChartView.currentSettings["colour_options_colourBy"];
                 let colour_options_specifyByFamily = FanChartView.currentSettings["colour_options_specifyByFamily"];
-                let colour_options_specifyByLocation =
-                    FanChartView.currentSettings["colour_options_specifyByLocation"];
+                let colour_options_specifyByLocation = FanChartView.currentSettings["colour_options_specifyByLocation"];
 
                 let legendDIV = document.getElementById("legendDIV");
                 let LegendTitle = document.getElementById("LegendTitle");
@@ -2373,15 +2365,15 @@ bioCheckTemplateManager.load();
                     innerCode += clrSwatchArray[index + 1] + " " + index * 10 + " - " + (index * 10 + 9);
                 }
                 innerCode += "<br/>" + clrSwatchArray[11] + " over 100";
-            } else  if (settingForColourBy == "Family" && settingForSpecifyByFamily == "numSpouses") {
+            } else if (settingForColourBy == "Family" && settingForSpecifyByFamily == "numSpouses") {
                 clrSwatchUNK =
                     "<svg width=20 height=20><rect width=20 height=20 style='fill:" +
                     "white" +
                     ";stroke:black;stroke-width:1;opacity:1' /><text font-weight=bold x=5 y=15>A</text></svg>";
-                innerCode = clrSwatchUNK + " unknown <br/>" ;
+                innerCode = clrSwatchUNK + " unknown <br/>";
                 for (let index = 0; index < 5; index++) {
                     innerCode += "<br/>";
-                    innerCode += clrSwatchArray[index ] + " " + (index )  ;
+                    innerCode += clrSwatchArray[index] + " " + index;
                 }
                 innerCode += "<br/>" + clrSwatchArray[7] + " over 4";
             } else if (settingForColourBy == "BioCheck") {
@@ -2766,7 +2758,7 @@ bioCheckTemplateManager.load();
             if (g && g.getBBox) {
                 let boundingBox = g.getBBox();
                 h = boundingBox.height;
-                condLog(boundingBox)
+                condLog(boundingBox);
                 if (boundingBox) {
                     svg.setAttribute(
                         "viewBox",
@@ -2844,7 +2836,6 @@ bioCheckTemplateManager.load();
                 screen.availWidth +
                 "/" +
                 screen.availHeight +
-               
                 ", " +
                 "Inner width/height: " +
                 window.innerWidth +
@@ -3706,7 +3697,7 @@ bioCheckTemplateManager.load();
                         "D"
                     )}</div>
 						</div>
-					</div>${mDateDIV}           
+					</div>${mDateDIV}
                     `;
                 }
             });
@@ -4486,10 +4477,10 @@ bioCheckTemplateManager.load();
             borderColor = "rgba(204, 102, 102, .5)";
         }
 
-         const SVGbtnDESC = `<svg width="30" height="30" viewBox="0 0 30 30" stroke="#25422d" fill="none" xmlns="http://www.w3.org/2000/svg">
+        const SVGbtnDESC = `<svg width="30" height="30" viewBox="0 0 30 30" stroke="#25422d" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M 4 5 L 10 5 L 10 9 L 24 9 M 16 9 L 16 13 L 24 13 M 10 9 L 10 19 L 24 19 M 16 19 L 16 23 L 24 23 M 16 23 L 16 27 L 24 27" fill="none" />
         </svg>`;
-        
+
         // condLog("popup  = ", popup);
         popup
             .append("foreignObject")
@@ -5746,7 +5737,7 @@ bioCheckTemplateManager.load();
                         thePeopleList[FanChartView.myAhnentafel.list[ahnNum]] &&
                         thePeopleList[FanChartView.myAhnentafel.list[ahnNum]]["biocheck"] &&
                         (thePeopleList[FanChartView.myAhnentafel.list[ahnNum]]["bioHasSources"] == false ||
-                            thePeopleList[FanChartView.myAhnentafel.list[ahnNum]]["biocheck"].isMarkedUnsourced() ))
+                            thePeopleList[FanChartView.myAhnentafel.list[ahnNum]]["biocheck"].isMarkedUnsourced()))
                 ) {
                     let badgeVars = FanChartView.theBadgeTracker[ahnNum][num];
                     FanChartView.addNewBadge(badgeVars.x, badgeVars.y, num, badgeVars.angle);
@@ -6007,10 +5998,7 @@ bioCheckTemplateManager.load();
                         showY = true;
                         showDs = true;
                         showAs = true;
-                    } else if (
-                        ahnNum == 1 &&
-                        thePeopleList[FanChartView.myAhnentafel.list[1]]._data.Gender == "Male"
-                    ) {
+                    } else if (ahnNum == 1 && thePeopleList[FanChartView.myAhnentafel.list[1]]._data.Gender == "Male") {
                         showY = true;
                         showDs = true;
                         showAs = true;
@@ -6056,10 +6044,7 @@ bioCheckTemplateManager.load();
                     // AND/OR by Y-DNA inheritance
                     if (ahnNum > 1) {
                         showY = true;
-                    } else if (
-                        ahnNum == 1 &&
-                        thePeopleList[FanChartView.myAhnentafel.list[1]]._data.Gender == "Male"
-                    ) {
+                    } else if (ahnNum == 1 && thePeopleList[FanChartView.myAhnentafel.list[1]]._data.Gender == "Male") {
                         showY = true;
                     }
                 }
@@ -6448,11 +6433,11 @@ bioCheckTemplateManager.load();
             // isMarkedUnsourced;
             // hasStyleIssues;
 
-
             if (
                 thePeopleList[FanChartView.myAhnentafel.list[ahnNum]] &&
                 thePeopleList[FanChartView.myAhnentafel.list[ahnNum]].biocheck &&
-               ( thePeopleList[FanChartView.myAhnentafel.list[ahnNum]].bioHasSources == false || theBioCheck.isMarkedUnsourced() )
+                (thePeopleList[FanChartView.myAhnentafel.list[ahnNum]].bioHasSources == false ||
+                    theBioCheck.isMarkedUnsourced())
             ) {
                 return true;
             }
@@ -7316,11 +7301,10 @@ bioCheckTemplateManager.load();
             } else if (settingForSpecifyByFamily == "numSpouses") {
                 let thePerp = thePeopleList[FanChartView.myAhnentafel.list[ahnNum]];
                 if (thePerp && thePerp._data.Spouses && thePerp._data.Spouses.length >= 0) {
-                    return thisColourArray[thePerp._data.Spouses.length ];
+                    return thisColourArray[thePerp._data.Spouses.length];
                 } else {
                     return "white";
                 }
-
             } else if (settingForSpecifyByFamily == "siblings") {
             }
         } else if (settingForColourBy == "Location") {
@@ -7409,14 +7393,8 @@ bioCheckTemplateManager.load();
                 return thisColourArray[0];
             }
         } else if (settingForColourBy == "DNAstatus") {
-            let DNAStatuses = [
-                "unknown",
-                "Confirmed by DNA",
-                "Confident",
-                "Uncertain",
-                "Non-biological",
-            ];
-            
+            let DNAStatuses = ["unknown", "Confirmed by DNA", "Confident", "Uncertain", "Non-biological"];
+
             if (ahnNum == 1) {
                 return "white";
             }
@@ -7437,19 +7415,17 @@ bioCheckTemplateManager.load();
                 // this person is female, so need to look at child's DataStatus.Mother setting - if it's 30, then the Mother is confirmed by DNA
                 if (
                     thePeopleList[FanChartView.myAhnentafel.list[childAhnNum]] &&
-                    thePeopleList[FanChartView.myAhnentafel.list[childAhnNum]]._data.DataStatus.Mother 
+                    thePeopleList[FanChartView.myAhnentafel.list[childAhnNum]]._data.DataStatus.Mother
                 ) {
-                    theStatusNum = thePeopleList[FanChartView.myAhnentafel.list[childAhnNum]]._data.DataStatus.Mother
+                    theStatusNum = thePeopleList[FanChartView.myAhnentafel.list[childAhnNum]]._data.DataStatus.Mother;
                 } else {
                     return "white";
                 }
             }
 
-                
-        //    console.log("Status For ", ahnNum, " is ", theStatusNum) ;
+            //    console.log("Status For ", ahnNum, " is ", theStatusNum) ;
 
-            
-            if (theStatusNum == 30 ) {
+            if (theStatusNum == 30) {
                 return thisColourArray[1];
             } else if (theStatusNum == 20) {
                 return thisColourArray[4];

--- a/views/fractalTree/FractalView.js
+++ b/views/fractalTree/FractalView.js
@@ -1,7 +1,7 @@
-    const SVGbtnDOWN =
-        '<SVG width=18 height=14 ><polyline points="0,0 18,0 9,14 0,0" fill="blue" stroke="blue"/><polyline points="5,7 13,7" fill="none" stroke="white" stroke-width=2 /></SVG>';
-    const SVGbtnUP =
-        '<SVG width=18 height=14 ><polyline points="0,14 18,14 9,0 0,14" fill="red" stroke="red"/><polyline points="5,8 13,8" fill="none" stroke="white" stroke-width=2 /> <polyline points="9,3 9,13" fill="none" stroke="white" stroke-width=2 /> </SVG>';
+const SVGbtnDOWN =
+    '<SVG width=18 height=14 ><polyline points="0,0 18,0 9,14 0,0" fill="blue" stroke="blue"/><polyline points="5,7 13,7" fill="none" stroke="white" stroke-width=2 /></SVG>';
+const SVGbtnUP =
+    '<SVG width=18 height=14 ><polyline points="0,14 18,14 9,0 0,14" fill="red" stroke="red"/><polyline points="5,8 13,8" fill="none" stroke="white" stroke-width=2 /> <polyline points="9,3 9,13" fill="none" stroke="white" stroke-width=2 /> </SVG>';
 /*
  * The WikiTree Dynamic Tree Viewer itself uses the D3.js library to render the graph.
  * Fractal Tree uses the D3 function for zooming and panning, but customizes the positioning of each leaf in the tree.
@@ -18,14 +18,9 @@
  * The Button Bar does not resize, but has clickable elements, which set global variables in the FractalView, then calls a redraw
  */
 
-import { BioCheckTemplateManager } from "../../lib/biocheck-api/src/BioCheckTemplateManager.js";
 import { theSourceRules } from "../../lib/biocheck-api/src/SourceRules.js";
 import { BioCheckPerson } from "../../lib/biocheck-api/src/BioCheckPerson.js";
 import { Biography } from "../../lib/biocheck-api/src/Biography.js";
-
-// initialization - just once
-let bioCheckTemplateManager = new BioCheckTemplateManager();
-bioCheckTemplateManager.load();
 
 (function () {
     const APP_ID = "FractalTree";
@@ -49,7 +44,7 @@ bioCheckTemplateManager.load();
     const AboutAdditionalProgrammers =
         "<A target=_blank href=https://www.wikitree.com/wiki/Duke-5773>Jonathan Duke</A>";
     const AboutAssistants = "Rob Pavey & Kay Knight";
-    const AboutLatestG2G = "";// "https://www.wikitree.com/g2g/1599363/recent-updates-to-the-fan-chart-tree-app-july-2023";
+    const AboutLatestG2G = ""; // "https://www.wikitree.com/g2g/1599363/recent-updates-to-the-fan-chart-tree-app-july-2023";
     const AboutHelpDoc = ""; // "https://www.wikitree.com/wiki/Space:Fan_Chart_app";
     const AboutOtherApps = "https://apps.wikitree.com/apps/clarke11007";
 
@@ -62,7 +57,7 @@ bioCheckTemplateManager.load();
     const SVGbtnUP =
         '<SVG width=18 height=14 ><polyline points="0,14 18,14 9,0 0,14" fill="red" stroke="red"/><polyline points="5,8 13,8" fill="none" stroke="white" stroke-width=2 /> <polyline points="9,3 9,13" fill="none" stroke="white" stroke-width=2 /> </SVG>';
 
-    const SVGbtnSETTINGS = `<svg height="16" width="16" version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+    const SVGbtnSETTINGS = `<svg height="16" width="16" version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
             viewBox="0 0 512 512"  xml:space="preserve">
         <style type="text/css">
             .st0{fill:#000000;}
@@ -87,9 +82,9 @@ bioCheckTemplateManager.load();
                 C511.995,216.122,506.472,210.32,499.453,210.004z M256.01,339.618c-46.164,0-83.622-37.438-83.622-83.612
                 c0-46.184,37.458-83.622,83.622-83.622s83.602,37.438,83.602,83.622C339.612,302.179,302.174,339.618,256.01,339.618z"/>
         </g>
-        </svg>`;    
-        
-    const SVGbtnINFO = `<svg fill="#0000FF" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+        </svg>`;
+
+    const SVGbtnINFO = `<svg fill="#0000FF" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
             width="16" height="16" viewBox="0 0 45.818 45.818"
             xml:space="preserve">
         <g>
@@ -99,7 +94,7 @@ bioCheckTemplateManager.load();
                 c0-2.12,1.718-3.836,3.837-3.836c2.118,0,3.837,1.716,3.837,3.836C26.746,12.133,25.027,13.851,22.909,13.851z"/>
         </g>
         </svg>`;
-    const SVGbtnHELP = `<svg fill="#006600" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+    const SVGbtnHELP = `<svg fill="#006600" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
             width="16" height="16" viewBox="0 0 95.334 95.334"
             xml:space="preserve">
         <g>
@@ -112,7 +107,7 @@ bioCheckTemplateManager.load();
                 c-0.292-0.303-0.448-0.71-0.434-1.13c0.444-12.341,10.47-22.008,22.823-22.008c12.593,0,22.837,10.245,22.837,22.837
                 C70.497,42.54,65.421,46.885,61.342,50.376z"/>
         </g>
-        </svg>`;        
+        </svg>`;
     /**
      * Constructor
      */
@@ -1111,38 +1106,32 @@ bioCheckTemplateManager.load();
             "&nbsp;&nbsp;</td>" +
             '</tr></table><DIV id=WarningMessageBelowButtonBar style="text-align:center; background-color:yellow;">Please wait while initial Fractal Tree is loading ...</DIV>';
 
-            var aboutHTML =
-                '<div id=aboutDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px;}">' +
-                `<span style="color:red; position:absolute; top:0.2em; right:0.6em; cursor:pointer;"><a onclick="FractalView.toggleAbout();">` +
-                SVGbtnCLOSE +
-                "</a></span>" +
-                "<H3>About the " +
-                FullAppName +
-                "</H3>" +
-                AboutPreamble +
-                "<br>" +
-                "<br>Last updated: " +
-                AboutUpdateDate +
-                "<br>App Icon: " +
-                AboutAppIcon +
-                "<br>Original Author: " +
-                AboutOriginalAuthor +
-                (AboutAdditionalProgrammers > ""
-                    ? "<br>Additional Programming by: " + AboutAdditionalProgrammers
-                    : "") +
-                "<br>Assistance and Code borrowed from: " +
-                AboutAssistants +
-                "<br/>" +
-                (AboutLatestG2G > ""
-                    ? "<br><A target=_blank href='" + AboutLatestG2G + "'>Latest G2G post</A>"
-                    : "") +
-                (AboutHelpDoc > ""
-                    ? "<br><A target=helpPage href='" + AboutHelpDoc + "'>Free Space help page</A>"
-                    : "") +
-                (AboutOtherApps > ""
-                    ? "<br><br><A target=helpPage href='" + AboutOtherApps + "'>Other Apps by Greg</A>"
-                    : "") +
-                "</div>";
+        var aboutHTML =
+            '<div id=aboutDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px;}">' +
+            `<span style="color:red; position:absolute; top:0.2em; right:0.6em; cursor:pointer;"><a onclick="FractalView.toggleAbout();">` +
+            SVGbtnCLOSE +
+            "</a></span>" +
+            "<H3>About the " +
+            FullAppName +
+            "</H3>" +
+            AboutPreamble +
+            "<br>" +
+            "<br>Last updated: " +
+            AboutUpdateDate +
+            "<br>App Icon: " +
+            AboutAppIcon +
+            "<br>Original Author: " +
+            AboutOriginalAuthor +
+            (AboutAdditionalProgrammers > "" ? "<br>Additional Programming by: " + AboutAdditionalProgrammers : "") +
+            "<br>Assistance and Code borrowed from: " +
+            AboutAssistants +
+            "<br/>" +
+            (AboutLatestG2G > "" ? "<br><A target=_blank href='" + AboutLatestG2G + "'>Latest G2G post</A>" : "") +
+            (AboutHelpDoc > "" ? "<br><A target=helpPage href='" + AboutHelpDoc + "'>Free Space help page</A>" : "") +
+            (AboutOtherApps > ""
+                ? "<br><br><A target=helpPage href='" + AboutOtherApps + "'>Other Apps by Greg</A>"
+                : "") +
+            "</div>";
 
         var settingsHTML = "";
 
@@ -1181,7 +1170,7 @@ bioCheckTemplateManager.load();
 
         var saveSettingsChangesButton = document.getElementById("saveSettingsChanges");
         saveSettingsChangesButton.addEventListener("click", (e) => settingsChanged(e));
-        
+
         FractalView.toggleAbout = function () {
             let aboutDIV = document.getElementById("aboutDIV");
             let settingsDIV = document.getElementById("settingsDIV");
@@ -2079,7 +2068,7 @@ bioCheckTemplateManager.load();
                         let hasSources = biography.validate();
                         thePeopleList[thePerson.getProfileId()]["biocheck"] = biography;
                         thePeopleList[thePerson.getProfileId()]["bioHasSources"] = hasSources;
-                        
+
                         console.log(
                             "async adding ",
                             thePerson.getReportName(),
@@ -2090,9 +2079,7 @@ bioCheckTemplateManager.load();
                             biography.hasStyleIssues(),
                             biography.isMissingSourcesHeading(),
                             thePeopleList[thePerson.getProfileId()].biocheck
-                            );
-
-
+                        );
                     }
                     FractalView.myAhnentafel.update(); // update the AhnenTafel with the latest ancestors
                     FractalView.workingMaxNumGens = Math.min(FractalView.maxNumGens, FractalView.numGensRetrieved + 1);
@@ -3192,7 +3179,6 @@ bioCheckTemplateManager.load();
         }
 
         let zoomFactor = Math.max(1, 1 / FractalView.currentScaleFactor);
- 
 
         var popup = this.svg
             .append("g")
@@ -3415,7 +3401,8 @@ bioCheckTemplateManager.load();
         condLog("findCategoriesOfAncestors");
         categoryList = [];
         stickerList = [];
-        let stickerInnerHTML = '<option selected value="-999">Do not use Badge #666#</option><option>CATEGORIES</option>';
+        let stickerInnerHTML =
+            '<option selected value="-999">Do not use Badge #666#</option><option>CATEGORIES</option>';
         for (let index = 1; index < 2 ** FractalView.numGens2Display; index++) {
             const thisPerp = thePeopleList[FractalView.myAhnentafel.list[index]];
             if (thisPerp) {


### PR DESCRIPTION
This change includes moving the loading by BioCheckTemplateManager
to tree.js and removing it from both FractalView and FanChart since
it only needs to be done once per browser session. Other changes to
the above two modules can be ascribed to Prettier.

Since Bio fields are now including in profile retrievals (required
by BioCheck), retrieval times are now longer (roughly double what it
was before) therefore the user has to turn BioCheck on explicitly
to get the functionality (i.e. it is off by default). However, if it is off,
a message in the info box tells them it is off.  

This version can be tested at https://apps.wikitree.com/apps/smit641/test/#view=cc7