### PR TITLE
ALE: Fix bug that caused connectors to have parents

### DIFF
--- a/views/ancestorLines/ale.css
+++ b/views/ancestorLines/ale.css
@@ -160,6 +160,52 @@ div.ale input {
 .ale #help-text:active {
   cursor: grabbing;
 }
+.ale #help-text h3 {
+  font-size: 1.3em;
+  margin-bottom: 0.5em;
+}
+
+.ale .bioReport {
+  background: white;
+  border-radius: 1em;
+  border: 3px solid forestgreen;
+  box-shadow: 0.5em 0.5em 0.5em 0.5em #ccc;
+  cursor: grab;
+  display: none;
+  position: absolute;
+  padding: 1.5em 1em 1em;
+  /* white-space: nowrap; */
+  z-index: 10000;
+}
+.ale .bioReport caption {
+  font-family: sans-serif;
+  font-size: 1.2em;
+  font-weight: bold;
+  text-align: left;
+  padding: 0.5em;
+  background: white;
+  border-top: 1px solid forestgreen;
+  border-bottom: 1px solid forestgreen;
+}
+
+.ale .bioReport w {
+  position: absolute;
+  top: 0;
+  left: 0.5em;
+  font-weight: bold;
+  cursor: pointer;
+}
+.ale .bioReport.wrap {
+  width: 80%;
+  white-space: normal;
+}
+.ale .bioReportTable ol {
+  margin-left: 2em;
+}
+.ale .bioReportTable td {
+  border-top: none;
+  border-bottom: none;
+}
 
 @media print {
   .ale-not-printable {

--- a/views/ancestorLines/ancestor_lines_explorer.js
+++ b/views/ancestorLines/ancestor_lines_explorer.js
@@ -11,14 +11,15 @@ export class AncestorLinesExplorer {
             start profile and draw their family tree up to the specified tree level. Although one might have specified N
             generations to be retrieved, the maximum level of the tree might be at more than N generations if an ancestor
             appears at more than one generation (i.e. level in the tree).
-        </p>
-        <p>
+        </p><p>
             <em><b>Warning</b>: A "full" (or complete) ancesstor tree of 15 generations or higher (e.g. for Windsor-1)
             WILL take a long time to retrieve and an even longer time to draw (a 15 generation tree can contain 32768 people).
             It may even crash your browser.
             It is possible, however, to retrieve 20 generations of trees that are relatively sparse in the older
-            generations.</em>
+            generations.</em> The more generations are requested in a load, the longer it may take, so please be patient.
+            Once loaded, you can save the data locally to your device and re-load it much faster later.
         </p>
+        <h3>Display and Interaction</h3>
         <ul>
             <li>
                 People that appear more than once in the tree are marked with a coloured square.
@@ -37,6 +38,12 @@ export class AncestorLinesExplorer {
             </li><li>
                 If you hover your pointer over a person, the birth- and death date and location of that person is displayed.
             </li><li>
+                The names of people marked as a <b>Brick Wall</b> (see below) are displayed in the selected colour.
+            </li>
+        </ul>
+        <h3>Options</h3>
+        <ul>
+            <li>
                 If the <b>Connectors</b> checkbox is ticked, a tree line will not be extended to beyond a duplicate
                 person if there is already a line containing this person.
             </li><li>
@@ -47,9 +54,30 @@ export class AncestorLinesExplorer {
                 The table has a header labeling each generation. This can be removed via the <b>Hide tree header</b>
                 tickbox.
             </li><li>
-                The <b>Brick wall colour</b> determines in which colour the names of people with no ancestors on record
-                are displayed. The default is black, i.e. they will be displayed like everyone else. If you want to
-                distinguish them, choose another colour.
+                The <b>Brick wall colour</b> determines, by default, in which colour the names of people with no ancestors on
+                record are displayed. The default is black, i.e. they will be displayed like everyone else. If you want to
+                distinguish them, choose another colour. You can control who is regarded as a "brick wall" by selecting the
+                approriate options in the <b>Add to Brick Wall</b> section.
+            </li><li>
+                If you inlcude <b>Bio Check</b> as a brick wall option, not only are profiles with Bio Check issues displayed in
+                the selected colour, but you can also see the Bio Check report by alt-clicking in their circle.
+            </li><li>
+                The size of the drawn tree is determined by the data, but also by the 3 controls below. You can fine tune the
+                tree layout by adjusting these parameters.
+                <ul>
+                  <li>
+                      The <b>Edge Factor</b> controls the horizontal distance between generations: the smaller the number,
+                      the closer the generations are on the horizontal axis.
+                  </li><li>
+                      The <b>Height Factor</b> controls the vertical distance between people at the same level in the tree.
+                      The larger the number, the further apart they are on the vertical axis.
+                  </li><li>
+                      The <b>Limit display to generation</b> value determines how many generations of the tree will be
+                      shown with all the people available rather than just those directly connected to a person of
+                      interest. If you select 'All',the complete tree will be shown (subject to the setting of the other
+                      parameters).
+                  </li>
+                </ul>
             </li><li>
                 Changes to tickbox options only take effect when <b>(Re-)Draw Tree</b> or <b>Go</b> is clicked. A colour
                 change takes effect immediately, while the remaining options can be applied immediatly by pressing enter
@@ -59,39 +87,19 @@ export class AncestorLinesExplorer {
             </li>
         </ul>
         <p>
-            The more generations are requested in a load, the longer it may take, so please be patient. Once loaded, you can
-            save the data locally to your device and re-load it much faster later.
-        </p>
-        <p>
-            If you provide a list of comma-separated WikiTree IDs in the 'People of Interest' field, all the lines to those
-            ancestors (if they are in the tree) will be highlighted. You can choose if these lines should be drawn in full,
-            or whether they should also stop at the tree level specified. Separately you can specify whether or not only
+            If you provide a list of comma-separated WikiTree IDs in the <b>People of Interest</b> field, all the lines to
+            those ancestors (if they are in the tree) will be highlighted. You can choose if these lines should be drawn in
+            full, or whether they should also stop at the tree level specified. Separately you can specify whether or not only
             these "lines of interest" should be displayed or not.
-        </p>
-        <p>
-            The size of the drawn tree is determined by the data, but also by the 3 controls below. You can fine tune the
-            tree layout by adjusting these parameters.
-        </p>
-        <ul>
-            <li>
-                The <b>Edge Factor</b> controls the horizontal distance between generations: the smaller the number, the
-                closer the generations are on the horizontal axis.
-            </li><li>
-                The <b>Height Factor</b> controls the vertical distance between people at the same level in the tree.
-                The larger the number, the further apart they are on the vertical axis.
-            </li><li>
-                The <b>Limit display to generation</b> value determines how many generations of the tree will be shown with
-                all the people available rather than just those directly connected to a person of interest. If you select
-                'All',the complete tree will be shown (subject to the setting of the other parameters).
-            </li>
-        </ul>
-        <p>
+        </p><p>
             If you find problems with this app or have suggestions for improvements, please
             <a style="color: navy; text-decoration: none" href="https://www.wikitree.com/wiki/Smit-641" , target="_blank"
             >let me know</a>.
+        </p><p>
+            You can double click in this box, or click the X in the top right corner to remove this About text.
         </p>
-        <p>You can double click in this box, or click the X in the top right corner to remove this About text.</p>
    `;
+    static nextZLevel = 10000;
 
     constructor(selector, startId) {
         this.selector = selector;
@@ -132,7 +140,7 @@ export class AncestorLinesExplorer {
               <span id="help-button" title="About this">?</span>
               <div id="help-text">${AncestorLinesExplorer.#helpText}</div>
               <br />
-              <fieldset>
+              <fieldset id="aleFieldset">
                 <legend id="aleOptions" title="Click to Close/Open the options">Options:</legend>
                 <table id="optionsTbl">
                   <tr>
@@ -234,7 +242,7 @@ export class AncestorLinesExplorer {
                     <td>
                       <label
                         for="aleBrickWallColour"
-                        title="Choose the colour for people with no known ancestors."
+                        title='Choose the colour for people categorised as a "brick wall".'
                         class="left">
                         Brick wall colour</label
                       >
@@ -242,7 +250,7 @@ export class AncestorLinesExplorer {
                         id="aleBrickWallColour"
                         type="color"
                         value="#000000"
-                        title="Choose the colour for people with no known ancestors." />
+                        title='Choose the colour for people chosen as a "brick wall".' />
                     </td>
                     <td>
                       <label for="tHFactor" title="Determines the display height of the tree." class="left"> Height Factor</label>
@@ -261,6 +269,74 @@ export class AncestorLinesExplorer {
                       </select>
                     </td>
                   </tr>
+                  <tr>
+                    <td style="text-align:right"><span title='Set what constitutes a "brick wall."'>
+                      Add to Brick Wall:&nbsp;<span></td>
+                    <td>
+                      <input
+                        id="noParents"
+                        type="checkbox"
+                        checked
+                        title="Anyone with no parents." />
+                      <label
+                        for="noParents"
+                        title="Anyone with no parents."
+                        class="right">
+                        No Parents</label
+                      >
+                    </td>
+                    <td>
+                      <input
+                        id="oneParent"
+                        type="checkbox"
+                        title="Anyone with only one parent." />
+                      <label
+                        for="oneParent"
+                        title="Anyone with only one parent."
+                        class="right">
+                        Only 1 Parent</label
+                      >
+                    </td>
+                    <td>
+                      <input
+                        id="noNoSpouses"
+                        type="checkbox"
+                        title='Anyone who does not have their "no more spouses" set.' />
+                      <label
+                        for="noNoSpouses"
+                        title='Anyone who does not have their "no more spouses" set.'
+                        class="right">
+                        No "no more spouses"</label
+                      >
+                    </td>
+                    <td>
+                      <input
+                        id="noNoChildren"
+                        type="checkbox"
+                        title='Anyone who does not have their "no more children" set.' />
+                      <label
+                        for="oneParent"
+                        title='Anyone who does not have their "no more children" set.'
+                        class="right">
+                        No "no more children"</label
+                      >
+                    </td>
+                  </tr>
+                  <tr>
+                    <td></td>
+                    <td>
+                      <input
+                        id="bioCheck"
+                        type="checkbox"
+                        title="Anyone with only one parent." />
+                      <label
+                        for="bioCheck"
+                        title="Anyone with issues reported by Bio Check."
+                        class="right">
+                        Bio Check</label
+                      >
+                    </td>
+                  </tr>
                 </table>
               </fieldset>
               <div class="floating-button-div" style="position: fixed; bottom: 20px; left: 20px;">
@@ -277,13 +353,23 @@ export class AncestorLinesExplorer {
 
         AncestorTree.init();
 
-        $("#generation").on("change", function () {
-            const maxGen = $("#generation").val();
-            AncestorLinesExplorer.setGetPeopleButtonText(maxGen);
-            AncestorLinesExplorer.updateMaxLevelSelection(maxGen, $("#maxLevel").val());
-        });
-        $("#getAncestorsButton").on("click", AncestorLinesExplorer.getAncestorsAndPaint);
-        $("#drawTreeButton").on("click", AncestorLinesExplorer.findPathsAndDrawTree);
+        $("#generation")
+            .off("change")
+            .on("change", function () {
+                const maxGen = $("#generation").val();
+                AncestorLinesExplorer.setGetPeopleButtonText(maxGen);
+                AncestorLinesExplorer.updateMaxLevelSelection(maxGen, $("#maxLevel").val());
+            });
+        $("#getAncestorsButton").off("click").on("click", AncestorLinesExplorer.getAncestorsAndPaint);
+        $("#drawTreeButton")
+            .off("click")
+            .on("click", function (e) {
+                if (document.getElementById("bioCheck").checked && !window.aleBiosLoaded) {
+                    AncestorLinesExplorer.getAncestorsAndPaint(e);
+                } else {
+                    AncestorLinesExplorer.findPathsAndDrawTree(e);
+                }
+            });
         $("#edgeFactor").keyup(function (e) {
             if (e.keyCode == 13) {
                 $("#drawTreeButton").click();
@@ -295,46 +381,58 @@ export class AncestorLinesExplorer {
             }
         });
 
-        $("#fileInput").on("change", AncestorLinesExplorer.handleFileUpload);
-        $("#savePeople").click(function (e) {
-            e.preventDefault();
-            const fileName = AncestorLinesExplorer.makeFilename();
-            AncestorLinesExplorer.saveArrayToFile(AncestorTree.toArray(), fileName);
-        });
-        $("#loadButton").click(function (e) {
-            e.preventDefault();
-            $("#fileInput").click();
-        });
-        $("#aleOptions").click(function (e) {
-            e.preventDefault();
-            $("#optionsTbl").slideToggle();
-        });
-        $("#aleBrickWallColour").on("change", function () {
-            $("#drawTreeButton").click();
-        });
+        $("#fileInput").off("change").on("change", AncestorLinesExplorer.handleFileUpload);
+        $("#savePeople")
+            .off("click")
+            .on("click", function (e) {
+                e.preventDefault();
+                const fileName = AncestorLinesExplorer.makeFilename();
+                AncestorLinesExplorer.saveArrayToFile(AncestorTree.toArray(), fileName);
+            });
+        $("#loadButton")
+            .off("click")
+            .on("click", function (e) {
+                e.preventDefault();
+                $("#fileInput").click();
+            });
+        $("#aleOptions")
+            .off("click")
+            .on("click", function (e) {
+                e.preventDefault();
+                $("#optionsTbl").slideToggle();
+            });
+        $("#aleBrickWallColour")
+            .off("change")
+            .on("change", function () {
+                $("#drawTreeButton").click();
+            });
         AncestorLinesExplorer.updateMaxLevelSelection(20, 5);
         AncestorLinesExplorer.retrieveOptionsFromCookie();
 
         const container = $("#theSvg");
         container.floatingScroll();
-        $("#slideLeft").on("click", function (event) {
-            event.preventDefault();
-            container.animate(
-                {
-                    scrollLeft: "-=300px",
-                },
-                "fast"
-            );
-        });
-        $("#slideRight").on("click", function (event) {
-            event.preventDefault();
-            container.animate(
-                {
-                    scrollLeft: "+=300px",
-                },
-                "fast"
-            );
-        });
+        $("#slideLeft")
+            .off("click")
+            .on("click", function (event) {
+                event.preventDefault();
+                container.animate(
+                    {
+                        scrollLeft: "-=300px",
+                    },
+                    "fast"
+                );
+            });
+        $("#slideRight")
+            .off("click")
+            .on("click", function (event) {
+                event.preventDefault();
+                container.animate(
+                    {
+                        scrollLeft: "+=300px",
+                    },
+                    "fast"
+                );
+            });
 
         if (typeof window.aleShowingInfo === "undefined") {
             window.aleShowingInfo = true;
@@ -344,24 +442,29 @@ export class AncestorLinesExplorer {
         }
 
         // Add click action to help button
-        const helpButton = document.getElementById("help-button");
-        helpButton.addEventListener("click", function () {
-            if (window.aleShowingInfo) {
-                wtViewRegistry.hideInfoPanel();
-                window.aleShowingInfo = false;
-            }
-            $("#help-text").slideToggle();
-        });
+        $("#help-button")
+            .off("click")
+            .on("click", function () {
+                if (window.aleShowingInfo) {
+                    wtViewRegistry.hideInfoPanel();
+                    window.aleShowingInfo = false;
+                }
+                $("#help-text").slideToggle();
+            });
         $("#help-text").draggable();
 
         // Add the help text as a pop-up
-        const help = document.getElementById("help-text");
-        help.addEventListener("dblclick", function () {
-            $(this).slideToggle();
-        });
-        document.querySelector("#help-text xx").addEventListener("click", function () {
-            $(this).parent().slideUp();
-        });
+        $("#help-text")
+            .off("dblclick")
+            .on("dblclick", function () {
+                $(this).slideToggle();
+            });
+        $("#help-text xx")
+            .off("click")
+            .on("click", function () {
+                $(this).parent().slideUp();
+            });
+        $(document).off("keyup", AncestorLinesExplorer.closePopup).on("keyup", AncestorLinesExplorer.closePopUp);
         $("#getAncestorsButton").click();
     }
 
@@ -383,6 +486,27 @@ export class AncestorLinesExplorer {
             return nrGenerations - 1;
         }
         return 4;
+    }
+
+    static closePopUp(e) {
+        if (e.key === "Escape") {
+            // Find the popup with the highest z-index
+            let highestZIndex = 0;
+            let lastPopup = null;
+            $(".bioReport:visible, #help-text:visible").each(function () {
+                const zIndex = parseInt($(this).css("z-index"), 10);
+                if (zIndex > highestZIndex) {
+                    highestZIndex = zIndex;
+                    lastPopup = $(this);
+                }
+            });
+
+            // Close the popup with the highest z-index
+            if (lastPopup) {
+                AncestorLinesExplorer.nextZLevel = highestZIndex;
+                lastPopup.slideUp();
+            }
+        }
     }
 
     static async getAncestorsAndPaint(event) {
@@ -407,6 +531,29 @@ export class AncestorLinesExplorer {
             AncestorLinesExplorer.setEarlySaAfricaIndiaIds();
         }
         AncestorLinesExplorer.saveOptionCookies();
+
+        const gen = $("#generation").val();
+        const maxNrPeople = 2 ** gen - 2;
+        const nrAncestorProfiles = AncestorTree.getPeople().size - 1;
+        $("#aleFieldset .report").remove();
+        $("#aleFieldset").append(
+            `<span class="report">Out of ${maxNrPeople} possible ancestors in ${gen} generations, ${
+                AncestorTree.getPeople().size
+            } (${((nrAncestorProfiles / maxNrPeople) * 100).toFixed(2)}%) have WikiTree profiles. ${
+                AncestorTree.duplicates.size
+            } (${(AncestorTree.duplicates.size / nrAncestorProfiles).toFixed(
+                2
+            )}%) are duplicates due to pedigree collapse.<span>`
+        );
+
+        AncestorTree.markBrickWalls({
+            noParents: document.getElementById("noParents").checked,
+            oneParent: document.getElementById("oneParent").checked,
+            noNoSpouses: document.getElementById("noNoSpouses").checked,
+            noNoChildren: document.getElementById("noNoChildren").checked,
+            bioCheck: document.getElementById("bioCheck").checked,
+        });
+
         const expandPaths = document.getElementById("expandPaths").checked;
         const onlyPaths = document.getElementById("onlyPaths").checked;
         const connectors = document.getElementById("connectors").checked;
@@ -441,8 +588,13 @@ export class AncestorLinesExplorer {
     }
 
     static async retrieveAncestorsFromWT(wtId, nrGenerations) {
+        window.aleBiosLoaded = document.getElementById("bioCheck").checked;
         const treeDepth = nrGenerations > 1 ? nrGenerations - 1 : 4;
-        const [theTreeRoot, buildTime] = await AncestorTree.buildTreeWithGetPeople(wtId, treeDepth);
+        const [theTreeRoot, buildTime] = await AncestorTree.buildTreeWithGetPeople(
+            wtId,
+            treeDepth,
+            window.aleBiosLoaded
+        );
         // console.log("theTreeRoot", theTreeRoot);
         console.log(`Tree size=${AncestorTree.getPeople().size}, buildTime=${buildTime}ms`);
         return theTreeRoot;
@@ -559,6 +711,11 @@ export class AncestorLinesExplorer {
             heightFactor: document.getElementById("tHFactor").value,
             maxLevel: document.getElementById("maxLevel").value,
             otherWtIds: document.getElementById("otherWtIds").value,
+            noParents: document.getElementById("noParents").checked,
+            oneParent: document.getElementById("oneParent").checked,
+            noNoSpouses: document.getElementById("noNoSpouses").checked,
+            noNoChildren: document.getElementById("noNoChildren").checked,
+            bioCheck: document.getElementById("bioCheck").checked,
         };
         // console.log(`Saving options ${JSON.stringify(options)}`);
         AncestorLinesExplorer.setCookie(AncestorLinesExplorer.#COOKIE_NAME, JSON.stringify(options));
@@ -579,6 +736,11 @@ export class AncestorLinesExplorer {
             $("#tHFactor").val(opt.heightFactor);
             $("#maxLevel").val(opt.maxLevel);
             $("#otherWtIds").val(opt.otherWtIds);
+            $("#noParents").attr("checked", opt.noParents);
+            $("#oneParent").attr("checked", opt.oneParent);
+            $("#noNoSpouses").attr("checked", opt.noNoSpouses);
+            $("#noNoChildren").attr("checked", opt.noNoChildren);
+            $("#bioCheck").attr("checked", opt.bioCheck);
         }
     }
 

--- a/views/ancestorLines/ancestor_tree.js
+++ b/views/ancestorLines/ancestor_tree.js
@@ -104,9 +104,9 @@ export class AncestorTree {
 
     static async makePagedCallAndAddPeople(reqIds, depth, start, limit, privateIdOffset, withBios) {
         console.log(`Calling getPeople with keys:${reqIds}, ancestors:${depth}, start:${start}, limit:${limit}`);
-        const starttime = performance.now();
+        let starttime = performance.now();
         const [resultByKey, ancestor_json] = await API.getPeople(reqIds, depth, start, limit, withBios);
-        const callTime = performance.now() - starttime;
+        let callTime = performance.now() - starttime;
         let profiles = ancestor_json ? Object.values(ancestor_json) : [];
         console.log(`Received ${profiles.length} profiles in ${callTime}ms.`);
         const notLoaded = new Set();
@@ -151,7 +151,7 @@ export class AncestorTree {
                 `Retrieving getPeople result page. keys:..., ancestors:${depth}, start:${start}, limit:${limit}`
             );
             starttime = performance.now();
-            let [, ancestor_json] = await API.getPeople(reqIds, depth, start, limit, withBios);
+            const [, ancestor_json] = await API.getPeople(reqIds, depth, start, limit, withBios);
             callTime = performance.now() - starttime;
             profiles = Object.values(ancestor_json);
             console.log(`Received ${profiles.length} profiles in ${callTime}ms.`);

--- a/views/ancestorLines/ancestor_tree.js
+++ b/views/ancestorLines/ancestor_tree.js
@@ -350,8 +350,10 @@ export class AncestorTree {
 
     static getD3Children(person, alreadyInTree) {
         const parents = [];
-        addParent(+person.getFatherId());
-        addParent(+person.getMotherId());
+        if (!(person instanceof LinkToPerson)) {
+            addParent(+person.getFatherId());
+            addParent(+person.getMotherId());
+        }
         return parents;
 
         function addParent(id) {

--- a/views/ancestorLines/ancestor_tree.js
+++ b/views/ancestorLines/ancestor_tree.js
@@ -151,7 +151,7 @@ export class AncestorTree {
                 `Retrieving getPeople result page. keys:..., ancestors:${depth}, start:${start}, limit:${limit}`
             );
             starttime = performance.now();
-            const [, ancestor_json] = await API.getPeople(reqIds, depth, start, limit, withBios);
+            let [, ancestor_json] = await API.getPeople(reqIds, depth, start, limit, withBios);
             callTime = performance.now() - starttime;
             profiles = Object.values(ancestor_json);
             console.log(`Received ${profiles.length} profiles in ${callTime}ms.`);

--- a/views/ancestorLines/api.js
+++ b/views/ancestorLines/api.js
@@ -23,21 +23,17 @@ export class API {
         "Mother",
         "Name",
         "Nicknames",
+        "NoChildren",
         // "Photo",
         "Prefix",
         "RealName",
         "Suffix",
     ];
 
-    static async getAncestorData(id, depth, fields = API.PRIMARY_FIELDS) {
-        return WikiTreeAPI.getAncestors(API.APP_ID, id, depth, fields);
-    }
+    static FOR_BIO_CHECK = ["Bio", "BirthDateDecade", "DeathDateDecade", "IsMember", "Manager", "Privacy"];
 
-    static async getRelatives(ids, fields = API.PRIMARY_FIELDS) {
-        return WikiTreeAPI.getRelatives(API.APP_ID, ids, fields);
-    }
-
-    static async getPeople(ids, ancestors = 0, start = 0, limit = API.GET_PERSON_LIMIT, fields = API.PRIMARY_FIELDS) {
+    static async getPeople(ids, ancestors = 0, start = 0, limit = API.GET_PERSON_LIMIT, withBios = false) {
+        const fields = withBios ? API.PRIMARY_FIELDS.concat(API.FOR_BIO_CHECK) : API.PRIMARY_FIELDS;
         const [status, resultByKey, people] = await WikiTreeAPI.getPeople(API.APP_ID, ids, fields, {
             ancestors: ancestors,
             start: start,

--- a/views/ancestorLines/display.js
+++ b/views/ancestorLines/display.js
@@ -4,6 +4,7 @@
 // the code I "stole" from you to make this app better.
 //
 import { AncestorTree } from "./ancestor_tree.js";
+import { AncestorLinesExplorer } from "./ancestor_lines_explorer.js";
 
 export function showTree(
     theTree,
@@ -327,7 +328,7 @@ export function showTree(
                 return d.data.getDisplayName();
             })
             .style("fill", (d) => {
-                return d.data.hasAParent() ? "inherit" : brickWallColour;
+                return d.data.isBrickWall() ? brickWallColour : "inherit";
             })
             .append("title")
             .text(function (d) {
@@ -443,8 +444,13 @@ export function showTree(
 
         // Toggle children on click.
         function toggleChildren(event, d) {
-            if (event.altKey) {
+            if (event.ctrlKey || event.metaKey) {
+                event.preventDefault();
                 console.log(d.data.toString(), d);
+                return;
+            }
+            if (event.altKey) {
+                showBioCheckReport($(this), d);
                 return;
             }
             if (event.shiftKey) {
@@ -516,6 +522,91 @@ export function showTree(
                 return false;
             }
         }
+    }
+
+    function showBioCheckReport(jqClicked, d) {
+        let person = d.data;
+        if (typeof person.bioCheckReport == "undefined" || person.bioCheckReport.length == 0) {
+            return;
+        }
+        const theClickedName = person.getWtId();
+        const familyId = theClickedName.replace(" ", "_") + "_bioCheck";
+        if ($(`#${familyId}`).length) {
+            $(`#${familyId}`).css("z-index", `${AncestorLinesExplorer.nextZLevel++}`).slideToggle();
+            return;
+        }
+
+        const bioReportTable = getBioCheckReportTable(person);
+        bioReportTable.attr("id", familyId);
+        showTable(jqClicked, bioReportTable, 10, 10);
+    }
+
+    function getBioCheckReportTable(person) {
+        const issueWord = person.bioCheckReport.length == 1 ? "issue" : "issues";
+        const bioCheckTable = $(
+            `<div class='bioReport' data-wtid='${person.getWtId()}'><w>↔</w><x>[ x ]</x><table class="bioReportTable">` +
+                `<caption>Bio Check found the following ${issueWord} with the biography of ${person.getDisplayName()}</caption>` +
+                "<tbody><tr><td><ol></ol></td></tr></tbody></table></div>"
+        );
+
+        const ol = bioCheckTable.find("tbody ol");
+        for (const [msg, subLines] of person.bioCheckReport) {
+            let msgLI = $("<li></li>").text(msg);
+            if (subLines && subLines.length > 0) {
+                const subList = $("<ul></ul>");
+                for (const line of subLines) {
+                    subList.append($("<li></li>").text(line));
+                }
+                msgLI = msgLI.append(subList);
+            }
+            ol.append(msgLI);
+        }
+        return bioCheckTable;
+    }
+
+    function showTable(jqClicked, theTable, lOffset, tOffset) {
+        // Attach the table to the container div
+        theTable.prependTo($("#aleContainer"));
+        theTable.draggable();
+        theTable.off("dblclick").on("dblclick", function () {
+            $(this).slideUp();
+        });
+
+        setOffset(jqClicked, theTable, lOffset, tOffset);
+        $(window).resize(function () {
+            if (theTable.length) {
+                setOffset(jqClicked, theTable, lOffset, tOffset);
+            }
+        });
+
+        theTable.css("z-index", `${AncestorLinesExplorer.nextZLevel++}`);
+        theTable.slideDown("slow");
+        theTable
+            .find("x")
+            .off("click")
+            .on("click", function () {
+                theTable.slideUp();
+            });
+        theTable
+            .find("w")
+            .off("click")
+            .on("click", function () {
+                theTable.toggleClass("wrap");
+            });
+    }
+
+    function getOffset(el) {
+        const rect = el.getBoundingClientRect();
+        return {
+            left: rect.left + window.scrollX,
+            top: rect.top + window.scrollY,
+        };
+    }
+
+    function setOffset(theClicked, elem, lOffset, tOffset) {
+        const theClickedOffset = getOffset(theClicked[0]);
+        const theLeft = theClickedOffset.left + lOffset;
+        elem.css({ top: theClickedOffset.top + tOffset, left: theLeft });
     }
 }
 

--- a/views/cc7/js/cc7.js
+++ b/views/cc7/js/cc7.js
@@ -86,7 +86,7 @@ export class CC7 {
                         links, they are placed in the "Above" group if they are older than the central person.
                         Otherwise they are in the "Below" group.
                     </li>
-                    <li><b>Missing Family</b> – Anyone who is missing a parent or does not have the "no more children" 
+                    <li><b>Missing Family</b> – Anyone who is missing a parent or does not have the "no more children"
                         or "no more spouses" boxes checked.
                     </li>
                 </ul>
@@ -3957,7 +3957,7 @@ export class CC7 {
             return [result[0]["status"], result[0]["resultByKey"], result[0]["people"]];
         } catch (error) {
             if (error.name !== "AbortError") {
-                console.warn(`Could not retrieve relatives up to degree ${depth} for ${key}: ${error}`);
+                console.warn(`Could not retrieve relatives up to degree ${depth} for ${ids}: ${error}`);
                 return [`${error}`, [], []];
             } else {
                 return ["aborted", [], []];


### PR DESCRIPTION
A connector is supposed to be just a link to a duplicate node representing the same person. This bug caused the connector to be displayed just like any other node (except for the title). Now a connector is always a leaf node.

Until this change is merged, it can be tested at https://apps.wikitree.com/apps/smit641/dynamic-tree/#view=ale