### PR TITLE
ALE/CC7: Fix relative count report

### DIFF
--- a/views/ancestorLines/ancestor_lines_explorer.js
+++ b/views/ancestorLines/ancestor_lines_explorer.js
@@ -282,7 +282,7 @@ export class AncestorLinesExplorer {
                         for="noParents"
                         title="Anyone with no parents."
                         class="right">
-                        No Parents</label
+                        No Parents [<span class="cnt">?</span>]</label
                       >
                     </td>
                     <td>
@@ -294,7 +294,7 @@ export class AncestorLinesExplorer {
                         for="oneParent"
                         title="Anyone with only one parent."
                         class="right">
-                        Only 1 Parent</label
+                        Only 1 Parent [<span class="cnt">?</span>]</label
                       >
                     </td>
                     <td>
@@ -306,7 +306,7 @@ export class AncestorLinesExplorer {
                         for="noNoSpouses"
                         title='Anyone who does not have their "no more spouses" set.'
                         class="right">
-                        No "no more spouses"</label
+                        No "no more spouses" [<span class="cnt">?</span>]</label
                       >
                     </td>
                     <td>
@@ -315,10 +315,10 @@ export class AncestorLinesExplorer {
                         type="checkbox"
                         title='Anyone who does not have their "no more children" set.' />
                       <label
-                        for="oneParent"
+                        for="noNoChildren"
                         title='Anyone who does not have their "no more children" set.'
                         class="right">
-                        No "no more children"</label
+                        No "no more children" [<span class="cnt">?</span>]</label
                       >
                     </td>
                   </tr>
@@ -333,7 +333,7 @@ export class AncestorLinesExplorer {
                         for="bioCheck"
                         title="Anyone with issues reported by Bio Check."
                         class="right">
-                        Bio Check</label
+                        Bio Check [<span class="cnt">?</span>]</label
                       >
                     </td>
                   </tr>
@@ -547,13 +547,17 @@ export class AncestorLinesExplorer {
             ).toFixed(2)}%) occur more than once due to pedigree collapse.</span>`
         );
 
-        AncestorTree.markBrickWalls({
+        const counts = AncestorTree.markAndCountBricks({
             noParents: document.getElementById("noParents").checked,
             oneParent: document.getElementById("oneParent").checked,
             noNoSpouses: document.getElementById("noNoSpouses").checked,
             noNoChildren: document.getElementById("noNoChildren").checked,
             bioCheck: document.getElementById("bioCheck").checked,
         });
+
+        for (const id of ["noParents", "oneParent", "noNoSpouses", "noNoChildren", "bioCheck"]) {
+            $(`label[for=${id}`).find("span.cnt").text(counts[id]);
+        }
 
         const expandPaths = document.getElementById("expandPaths").checked;
         const onlyPaths = document.getElementById("onlyPaths").checked;

--- a/views/ancestorLines/ancestor_lines_explorer.js
+++ b/views/ancestorLines/ancestor_lines_explorer.js
@@ -535,13 +535,14 @@ export class AncestorLinesExplorer {
         const gen = $("#generation").val();
         const maxNrPeople = 2 ** gen - 2;
         const nrAncestorProfiles = AncestorTree.profileCount - 1;
+        const nrDuplicates = AncestorTree.nrDuplicatesUpToGen(gen);
         $("#aleFieldset .report").remove();
         $("#aleFieldset").append(
             `<span class="report">Out of ${maxNrPeople} possible direct ancestors in ${gen} generations, ${nrAncestorProfiles} (${(
                 (nrAncestorProfiles / maxNrPeople) *
                 100
-            ).toFixed(2)}%) have WikiTree profiles and out of them, ${AncestorTree.duplicates.size} (${(
-                (AncestorTree.duplicates.size / nrAncestorProfiles) *
+            ).toFixed(2)}%) have WikiTree profiles and out of them, ${nrDuplicates} (${(
+                (nrDuplicates / nrAncestorProfiles) *
                 100
             ).toFixed(2)}%) occur more than once due to pedigree collapse.</span>`
         );

--- a/views/ancestorLines/ancestor_tree.js
+++ b/views/ancestorLines/ancestor_tree.js
@@ -13,12 +13,14 @@ export class AncestorTree {
     static duplicates = new Map();
     static genCounts = [];
     static profileCount = 0;
+    static requestedGen = 0;
 
     static init() {
         AncestorTree.#people = new Map();
         AncestorTree.#peopleByWtId.clear();
         AncestorTree.duplicates.clear();
         AncestorTree.profileCount = 0;
+        AncestorTree.requestedGen = 0;
     }
 
     static clear() {
@@ -29,6 +31,7 @@ export class AncestorTree {
         AncestorTree.maxGeneration = 0;
         AncestorTree.genCounts = [];
         AncestorTree.profileCount = 0;
+        AncestorTree.requestedGen = 0;
     }
 
     static replaceWith(treeArray) {
@@ -42,6 +45,7 @@ export class AncestorTree {
 
     static async buildTreeWithGetPeople(wtId, depth, withBios) {
         const starttime = performance.now();
+        AncestorTree.requestedGen = depth + 1;
         let remainingDepth = depth;
         let reqDepth = Math.min(API.MAX_API_DEPTH, remainingDepth);
         let start = 0;
@@ -183,7 +187,7 @@ export class AncestorTree {
             if (p.isDuplicate() && !AncestorTree.duplicates.has(id)) {
                 AncestorTree.duplicates.set(id, ++n);
             }
-            AncestorTree.profileCount += p.getNrCopies();
+            AncestorTree.profileCount += p.getNrCopies(AncestorTree.requestedGen);
         }
         console.log(`nr profiles=${AncestorTree.profileCount}, nr duplicates=${AncestorTree.duplicates.size}`);
         console.log(`generation counts: ${AncestorTree.genCounts}`, AncestorTree.genCounts);
@@ -339,6 +343,17 @@ export class AncestorTree {
             }
             return val;
         }
+    }
+
+    static nrDuplicatesUpToGen(gen) {
+        let cnt = 0;
+        for (const dId of AncestorTree.duplicates.keys()) {
+            const dPerson = AncestorTree.#people.get(+dId);
+            if (dPerson.getNrCopies(gen) > 1) {
+                ++cnt;
+            }
+        }
+        return cnt;
     }
 
     static toArray() {

--- a/views/ancestorLines/ancestor_tree.js
+++ b/views/ancestorLines/ancestor_tree.js
@@ -319,30 +319,43 @@ export class AncestorTree {
         }
     }
 
-    static markBrickWalls(opt) {
+    static markAndCountBricks(opt) {
+        let nrNoParents = 0;
+        let nrOneParent = 0;
+        let nrNoNoSpouses = 0;
+        let nrNoNoChildren = 0;
+        let nrBioIssue = 0;
         AncestorTree.#people.forEach((person) => {
-            person.setBrickWall(isBrickWall(person));
+            let isBrick = false;
+            if (!person.hasAParent()) {
+                ++nrNoParents;
+                isBrick ||= opt.noParents;
+            }
+            if ((person.getFatherId() && !person.getMotherId()) || (!person.getFatherId() && person.getMotherId())) {
+                ++nrOneParent;
+                isBrick ||= opt.oneParent;
+            }
+            if (person._data.DataStatus?.Spouse != "blank") {
+                ++nrNoNoSpouses;
+                isBrick ||= opt.noNoSpouses;
+            }
+            if (person._data.NoChildren != 1) {
+                ++nrNoNoChildren;
+                isBrick ||= opt.noNoChildren;
+            }
+            if (person.hasBioIssues) {
+                ++nrBioIssue;
+                isBrick ||= opt.bioCheck;
+            }
+            person.setBrickWall(isBrick);
         });
-        function isBrickWall(person) {
-            let val = false;
-            if (opt.bioCheck) {
-                val = person.hasBioIssues;
-            }
-            if (!val && opt.noParents) {
-                val = !person.hasAParent();
-            }
-            if (!val && opt.noNoChildren) {
-                val = person._data.NoChildren != 1;
-            }
-            if (!val && opt.noNoSpouses) {
-                val = person._data.DataStatus?.Spouse != "blank";
-            }
-            if (!val && opt.oneParent) {
-                val =
-                    (person.getFatherId() && !person.getMotherId()) || (!person.getFatherId() && person.getMotherId());
-            }
-            return val;
-        }
+        return {
+            noParents: nrNoParents,
+            oneParent: nrOneParent,
+            noNoSpouses: nrNoNoSpouses,
+            noNoChildren: nrNoNoChildren,
+            bioCheck: window.aleBiosLoaded ? nrBioIssue : "?",
+        };
     }
 
     static nrDuplicatesUpToGen(gen) {

--- a/views/ancestorLines/person.js
+++ b/views/ancestorLines/person.js
@@ -97,8 +97,9 @@ export class Person {
     isAtGeneration(n) {
         return this.generations.has(n);
     }
-    getNrCopies() {
-        return [...this.generations.values()].reduce((acc, cur) => acc + cur, 0);
+    getNrCopies(upToGen) {
+        // Count how many copies of this profile are there within upToGen generations
+        return [...this.generations.entries()].reduce((acc, [gen, cnt]) => (gen <= upToGen ? acc + cnt : acc), 0);
     }
     isBelowGeneration(n) {
         for (const g of this.generations.keys()) {


### PR DESCRIPTION
The report was incorrect if the same ancestor appeared at two different degrees.

This change also includes 2 UI improvements:
* In the CC7 missing family subset filter, the checkboxes defining the subset are now displayed if Missing Family is selected, allowing the user to see (and change) what the settings are without having to open Settings first. The checkboxes are still in the settings tab as well.
* In the ALE, counts of the number of profiles in that category are added after each checkbox defining the composition of a brick wall.

Until merged, the changes can be test-driven at https://apps.wikitree.com/apps/smit641/dynamic-tree/