### PR TITLE
Super Big: Fixed duplicate Private Children / non married Connectors

### DIFF
--- a/views/superBigFamTree/SuperBigFamView.js
+++ b/views/superBigFamTree/SuperBigFamView.js
@@ -2113,6 +2113,10 @@
         SuperBigFamView.VlinesATC = [];
         SuperBigFamView.VlinesATCpeep = [];        
 
+        for (var ChunkID in SuperBigFamView.theChunkCollection) {
+            SuperBigFamView.theChunkCollection[ChunkID]["YsList"] = [];
+        }
+
         linesDIV.innerHTML =
             (SuperBigFamView.currentSettings["general_options_showBoxesAroundAncFamilies"] == true
                 ? drawBoxesAround()
@@ -2279,6 +2283,7 @@
                 Chunk: newChunk,
                 CodesList: [theCode],
                 Settings: "",
+                YsList : []
             };
         }
 
@@ -3200,6 +3205,31 @@
         return { hasChanged: hasChanged, centre: bigDropX, kids: kidXsArray };
     }
 
+    
+    function addCrossBarYtoChunkYsList(Chunk, crossBarY) {
+        if (SuperBigFamView.theChunkCollection[Chunk].YsList.indexOf(crossBarY) == -1){
+            SuperBigFamView.theChunkCollection[Chunk].YsList.push(crossBarY);
+        }
+    }
+
+    function extraHeightForChunk(Chunk) {
+        if (!SuperBigFamView.theChunkCollection[Chunk].YsList) {
+            return 0;
+        } else if (SuperBigFamView.theChunkCollection[Chunk].YsList.length < 2) {
+            return 0;
+        } else {
+            let theMin = SuperBigFamView.theChunkCollection[Chunk].YsList[0];
+            let theMax = SuperBigFamView.theChunkCollection[Chunk].YsList[0];
+            for (let y = 0; y < SuperBigFamView.theChunkCollection[Chunk].YsList.length; y++) {
+                const thisY = SuperBigFamView.theChunkCollection[Chunk].YsList[y];
+                theMin = Math.min(theMin, thisY);
+                theMax = Math.max(theMax, thisY);
+            }
+            return (theMax - theMin);
+        }
+        
+    }
+
     function checkCrossBarYwithATC(theY, minX, maxX) {
         let doLoop = true;
         let loopCounter = 0;
@@ -3224,11 +3254,11 @@
                         // condLog("Conflict with [", pts.min, pts.max, "] and ", minX, maxX);
                         doLoop = true;
                     } else if (minX == pts.max) {
-                        // condLog("Conflict bprder with [", pts.min, pts.max, "] and ", minX);
+                        // condLog("Conflict border with [", pts.min, pts.max, "] and ", minX);
                         doLoop = true;
                         thisY += 50;
                     } else if (maxX == pts.min) {
-                        // condLog("Conflict bprder with [", pts.min, pts.max, "] and ", minX);
+                        // condLog("Conflict border with [", pts.min, pts.max, "] and ", minX);
                         doLoop = true;
                         thisY += 50;
                     }
@@ -3247,6 +3277,7 @@
         // condLog("OK with ", thisY);
         return thisY;
     }
+
 
     function drawLinesForFamilyOf(code, kidPrefix = "", levelNum = 0, clrNum = -1) {
         condLog ("drawLinesForFamilyOf", code, "*" + kidPrefix + "*", levelNum, clrNum);
@@ -3890,6 +3921,8 @@
                 // condLog(dropLines);
                 if (childrenXs.length > 0) {
                     allLinesPolySVG += equalsLine + tBarVertLine + dropLines;
+                    addCrossBarYtoChunkYsList(primaryLeaf.Chunk, crossBarY);
+
                 } else {
                     allLinesPolySVG += equalsLine;
                 }
@@ -4071,6 +4104,7 @@
             // condLog(dropLines);
             if (childrenXs.length > 0) {
                 allLinesPolySVG += equalsLine + tBarVertLine + dropLines;
+                addCrossBarYtoChunkYsList(primaryLeaf.Chunk, crossBarY);
             }
         }  else if (doNotDisplaySpousesList.length > 0) {
             condLog("INSERT DRAWING LINES TO KIDS ROUTINE HERE :")
@@ -4300,6 +4334,7 @@
                         "childrenMaxX: " + childrenMaxX
                     );
                     allLinesPolySVG += equalsLine + tBarVertLine + dropLines;
+                    addCrossBarYtoChunkYsList(primaryLeaf.Chunk, crossBarY);
                 }
             }
         }
@@ -4481,6 +4516,7 @@
         //        allLinesPolySVG += equalsLine + tBarVertLine + dropLines;
         //    } else {
 
+    
         condLog("** drawLinesForPrimaryOnlyAndParents : END");
         return equalsLine + tBarVertLine;
         //    }
@@ -5788,6 +5824,10 @@
                 AmaxHeights[a] = thisMaxHeight;
             }
 
+            // STEP 1.5 : Do an initial pass of drawLines to figure out any extra heights needed because of crossing lines
+            SuperBigFamView.drawLines;
+            endisableButtons(false);
+            
             // STEP 2 : Position each cluster along the primary axis, left or right of it based on paternal vs maternal lines
             let thisY = 0;
             let cuzHeight = 0;
@@ -5818,6 +5858,8 @@
                 if (a == numA) {
                     thisMaxHeight = vBoxHeight;
                 }
+                thisMaxHeight += extraHeightForChunk("A" + a);
+
                 condLog("maxHeights for ", a, ": maxHeight = ", thisMaxHeight);
                 if (showInLaws) {
                     thisMaxHeight += maxInLawsArray[a] * AmaxHeights[a];
@@ -8075,6 +8117,7 @@
                         Chunk: newLeaf.Chunk,
                         CodesList: [newLeaf.Code],
                         Settings: "",
+                        YsList:[]
                     };
                 } else if (!SuperBigFamView.theChunkCollection[newLeaf.Chunk].CodesList) {
                     SuperBigFamView.theChunkCollection[newLeaf.Chunk].CodesList = [newLeaf.Code];
@@ -8127,6 +8170,7 @@
                     Chunk: newLeaf.Chunk,
                     CodesList: [newLeaf.Code],
                     Settings: "",
+                    YsList:[]
                 };
             }
         }

--- a/views/superBigFamTree/SuperBigFamView.js
+++ b/views/superBigFamTree/SuperBigFamView.js
@@ -3389,8 +3389,15 @@
         }
 
         if (!primaryLeafPerson._data.SpousesOrdered) {
+               condLog(
+            "drawLines:" +
+                code +
+                "-" +
+                kidPrefix +
+                "- creating orderedPartners:");
+
             let orderedPartners = [];
-            for (let sp in primaryLeafPerson._data.Spouses) {
+            for (let sp = 0; sp < primaryLeafPerson._data.Spouses.length; sp++) {
                 const thisPartner = primaryLeafPerson._data.Spouses[sp];
                 orderedPartners.push(thisPartner.marriage_date + "|" + thisPartner.Id);
             }
@@ -3401,43 +3408,91 @@
 
         let totalNumExtraSpouses = 0;
 
+        condLog(
+            code,
+            "DNDlist:",
+            doNotDisplaySpousesList,
+            "ordPs",
+            primaryLeafPerson._data.SpousesOrdered,
+            "Spouses:",
+            primaryLeafPerson._data.Spouses
+        );
         for (let ord = 0; ord < primaryLeafPerson._data.SpousesOrdered.length; ord++) {
             const spouseOrdered = primaryLeafPerson._data.SpousesOrdered[ord];
             let spID = spouseOrdered.substr(spouseOrdered.indexOf("|") + 1);
 
-            for (let sp = 0; spID > 0 && sp < primaryLeafPerson._data.Spouses.length; sp++) {
+            for (let sp = 0; /* spID > 0 && */ sp < primaryLeafPerson._data.Spouses.length; sp++) {
                 // const thisSpouse = primaryLeafPerson._data.Spouses[sp];
 
-                let primarySpouse = SuperBigFamView.theLeafCollection[code + "P" + (sp + 1)];
-                let thisSpouseDIV = document.getElementById("wedgeInfo-" + code + "P" + (sp + 1));
+                if (spID > 0){
+                    let primarySpouse = SuperBigFamView.theLeafCollection[code + "P" + (sp + 1)];
+                    let thisSpouseDIV = document.getElementById("wedgeInfo-" + code + "P" + (sp + 1));
 
-                if (!primarySpouse) {
-                    continue; /// go back to the next value of sp
+                    if (!primarySpouse) {
+                        continue; /// go back to the next value of sp
+                    }
+                    let primarySpouseID = primarySpouse.Id;
+
+                    if (!thisSpouseDIV) {
+                        continue;
+                    } else if (thisSpouseDIV.parentNode.parentNode.style.display == "none") {
+                        continue;
+                    } else if (primarySpouseID != spID) {
+                        continue;
+                    }
+
+                    totalNumExtraSpouses++;
                 }
-                let primarySpouseID = primarySpouse.Id;
-
-                if (!thisSpouseDIV) {
-                    continue;
-                } else if (thisSpouseDIV.parentNode.parentNode.style.display == "none") {
-                    continue;
-                } else if (primarySpouseID != spID) {
-                    continue;
+            
+                if (
+                    primaryLeafPerson._data.Spouses[sp].DoNotDisplay &&
+                    primaryLeafPerson._data.Spouses[sp].DoNotDisplay == 1
+                ) {
+                    doNotDisplaySpousesList.push(primaryLeafPerson._data.Spouses[sp].Id);
+                    condLog(
+                        "NEED to add DRAW LINES for this SPECIAL CASE if there are children from: ",
+                        primaryLeafPerson._data.Spouses[sp]
+                    );
                 }
 
-                totalNumExtraSpouses++;
             }
         }
 
         let currentSpNum = 0;
+        condLog(
+            "drawLines:" +
+                code +
+                "-" +
+                kidPrefix +
+                "-spOrd:" +
+                primaryLeafPerson._data.SpousesOrdered.length +
+                "-Sp:" +
+                primaryLeafPerson._data.Spouses.length +
+                "-DND:" +
+                doNotDisplaySpousesList.length +
+                "-total:" +
+                totalNumExtraSpouses +
+                ":3441 - " + primaryLeafPerson._data.BirthNamePrivate
+        );
 
         for (let ord = 0; ord < primaryLeafPerson._data.SpousesOrdered.length; ord++) {
                 const spouseOrdered = primaryLeafPerson._data.SpousesOrdered[ord];
                 let spID = spouseOrdered.substr(spouseOrdered.indexOf("|") + 1);
-            
+             condLog(
+                 "drawLines:" +
+                     code +
+                     "-" +
+                     kidPrefix +
+                     "-" +
+                     spID +
+                     "-" +
+                     spouseOrdered +
+                     ":3446"
+             );
 
             for (let sp = 0; spID > 0 && sp < primaryLeafPerson._data.Spouses.length; sp++) {
                 // const thisSpouse = primaryLeafPerson._data.Spouses[sp];
-
+                condLog("drawLines:" + code + "-" + kidPrefix +"-" + spID + "-" + sp + "-" + primaryLeafPerson._data.Spouses[sp].Id + ":3449");
                 let primarySpouse = SuperBigFamView.theLeafCollection[code + "P" + (sp + 1)];
                 let thisSpouseDIV = document.getElementById("wedgeInfo-" + code + "P" + (sp + 1));
 
@@ -3448,23 +3503,23 @@
                         break;
                     }
                 }
-
+                condLog("drawLines:" + code + "-" + kidPrefix + "-" + spID + "-" + sp + ":3460");
                 if (!primarySpouse) {
                     condLog("NO Primary Spouse exists in theLeafCollection !");
-                    if (
-                        primaryLeafPerson._data.Spouses[sp].DoNotDisplay &&
-                        primaryLeafPerson._data.Spouses[sp].DoNotDisplay == 1
-                    ) {
-                        doNotDisplaySpousesList.push(primaryLeafPerson._data.Spouses[sp].Id);
-                        condLog(
-                            "NEED to add DRAW LINES for this SPECIAL CASE if there are children from: ",
-                            primaryLeafPerson._data.Spouses[sp]
-                        );
-                    }
+                    // if (
+                    //     primaryLeafPerson._data.Spouses[sp].DoNotDisplay &&
+                    //     primaryLeafPerson._data.Spouses[sp].DoNotDisplay == 1
+                    // ) {
+                    //     doNotDisplaySpousesList.push(primaryLeafPerson._data.Spouses[sp].Id);
+                    //     condLog(
+                    //         "NEED to add DRAW LINES for this SPECIAL CASE if there are children from: ",
+                    //         primaryLeafPerson._data.Spouses[sp]
+                    //     );
+                    // }
                     continue; /// go back to the next value of sp
                 }
                 let primarySpouseID = primarySpouse.Id;
-
+                condLog("drawLines:" + code + "-" + kidPrefix + "-" + spID + "-" + sp + ":3476");
                 if (!thisSpouseDIV) {
                     condLog("NO Primary Spouse exists in WedgeInfo- DIVs collection !");
                     continue;
@@ -3475,7 +3530,12 @@
                 }
 
                 currentSpNum++;
-
+                condLog("drawLines:" + code + "-" + kidPrefix + "-" + spID + "-" + sp + ":3487 ==> spouse # "+ currentSpNum);
+                condLog(
+                    "Let's display ",
+                    primaryLeafPerson._data.Spouses[sp].DoNotDisplay , primaryLeafPerson._data.BirthNamePrivate + " + ",
+                    primarySpouse
+                );
                 let minX = Math.min(primaryLeaf.x, primarySpouse.x);
                 let maxX = Math.max(primaryLeaf.x, primarySpouse.x);
                 let minY = Math.min(primaryLeaf.y, primarySpouse.y);
@@ -6919,6 +6979,7 @@
 
         // NOTE: orderedPartners includes a default PsByID[0] for children with NO other parent
         //  - so - if there ARE partner spouses, then the orderedPartners.length > 1   !!!!
+        let numSpousesDisplayed = 0;
         if (orderedPartners.length > 1) {
             spouseWidth =
                 (orderedPartners.length - 1) * (1.0 * thisBoxWidth + 20) +
@@ -7009,6 +7070,7 @@
                     repositionThisSpousesFamily(thisPartner, thisPcode);
                 }
             }
+            numSpousesDisplayed = thePartnerNum;
         }
         // (STEP 6) Calculate and Return overall Dimensions of entire package
         dims.width = Math.max(thisBoxWidth, dims.width, spouseWidth);
@@ -7030,6 +7092,11 @@
         // SPECIAL CASE:  If # of spouses == 0 AND # of kids > 0 ... then back up the main Leaf.x by half a BoxWidth ???  To avoid the weird half-offset look
         if (thisLeafPerson._data.Spouses.length == 0 && orderedKids.length > 0) {
             thisLeaf.x -= thisBoxWidth/2 - 10;
+            
+            
+        // SPECIAL CASE:  If # of spouses displayed == 0 AND # of kids > 0 ... then back up the main Leaf.x by half a BoxWidth ???  To avoid the weird half-offset look
+        } else if (thisLeafPerson._data.Spouses.length > 0 && numSpousesDisplayed == 0 && orderedKids.length > 0) {
+            thisLeaf.x -= thisBoxWidth / 2 - 10;
         } 
         
         return dims;
@@ -8462,7 +8529,7 @@
 
             let appMode = SuperBigFamView.numAncGens2Display + "|" + SuperBigFamView.numDescGens2Display + "|" + SuperBigFamView.numCuzGens2Display;
             let parentComboKey = thePeopleList[kidID]._data.Father + "|" + thePeopleList[kidID]._data.Mother;
-            // console.log(
+            // condLog(
             //     thePeopleList[kidID]._data.Name,
             //     thePeopleList[kidID]._data.Father,
             //     thePeopleList[kidID]._data.Mother,

--- a/views/superBigFamTree/SuperBigFamView.js
+++ b/views/superBigFamTree/SuperBigFamView.js
@@ -224,6 +224,8 @@
 
     /** Static variable to hold unique ids for private persons **/
     SuperBigFamView.nextPrivateId = 50000000;
+    SuperBigFamView.maxPrivateId = 50000000;
+    SuperBigFamView.privateChildren2ParentsTracker = {};
 
     /** Placeholder to hold EXTRA SPOUSES that aren't showing up during regular getPeople searches - like unmarried spouses - but children link to both parents. */
     SuperBigFamView.listOfExtraSpousesToAddToList = [];
@@ -793,9 +795,9 @@
 
                         {
                             optionName: "vSpacing",
-                            label: "Vertical Spacing (from 1 to 10)",
+                            label: "Vertical Spacing (from 1 to 20)",
                             type: "number",
-                            defaultValue: 7,
+                            defaultValue: 10,
                         },
                         { optionName: "break0.5", type: "br" },
                         {
@@ -2520,22 +2522,26 @@
                                 drawColour +
                                 `" stroke-width="3" />`;
 
-                             equalsLine +=
-                                 `<polyline points="` +
-                                 (maxX + (3 * boxWidth) / 2 + 20) +
-                                 "," +
-                                 (primaryLeaf.y + 120 - currentSpNum) +
-                                 " " +
-                                 (maxX + boxWidth / 4 + theTweak4Max) +
-                                 "," +
-                                 (topEqualsY + 30 + theTweak4MaxAngle) +
-                                 " " +
-                                 (maxX /* - 20 */ + theTweak4Max) +
-                                 "," +
-                                 (topEqualsY + 30) +
-                                 `" fill="none" stroke="` +
-                                 drawColour +
-                                 `" stroke-width="3" />`;
+                             if (doNotDisplayMarriageEquals(primaryLeaf.Id, primarySpouseID)) {
+                                // do nothing
+                            } else {
+                                equalsLine +=
+                                    `<polyline points="` +
+                                    (maxX + (3 * boxWidth) / 2 + 20) +
+                                    "," +
+                                    (primaryLeaf.y + 120 - currentSpNum) +
+                                    " " +
+                                    (maxX + boxWidth / 4 + theTweak4Max) +
+                                    "," +
+                                    (topEqualsY + 30 + theTweak4MaxAngle) +
+                                    " " +
+                                    (maxX /* - 20 */ + theTweak4Max) +
+                                    "," +
+                                    (topEqualsY + 30) +
+                                    `" fill="none" stroke="` +
+                                    drawColour +
+                                    `" stroke-width="3" />`;
+                            }
                         } 
                     } else if (pNum == 1) {
                         if (currentSpNum > 3) {
@@ -2563,18 +2569,22 @@
                                 drawColour +
                                 `" stroke-width="3" />`;
 
-                            equalsLine +=
-                                `<polyline points="` +
-                                (minX - (3 * boxWidth/2) - 20) +
-                                "," +
-                                (primaryLeaf.y + 120 - currentSpNum) +
-                                " " +
-                                (minX + boxWidth / 4) +
-                                "," +
-                                (topEqualsY + 30) +
-                                `" fill="none" stroke="` +
-                                drawColour +
-                                `" stroke-width="3" />`;
+                             if (doNotDisplayMarriageEquals(primaryLeaf.Id, primarySpouseID)) {
+                                // do nothing
+                            } else {
+                                equalsLine +=
+                                    `<polyline points="` +
+                                    (minX - (3 * boxWidth/2) - 20) +
+                                    "," +
+                                    (primaryLeaf.y + 120 - currentSpNum) +
+                                    " " +
+                                    (minX + boxWidth / 4) +
+                                    "," +
+                                    (topEqualsY + 30) +
+                                    `" fill="none" stroke="` +
+                                    drawColour +
+                                    `" stroke-width="3" />`;
+                            }
                         }
                     }
 
@@ -2640,6 +2650,7 @@
     }
 
     function doNotDisplayMarriageEquals(sp1ID, sp2ID) {
+        condLog("doNotDisplayMarriageEquals", sp1ID, sp2ID);
         if (!thePeopleList[sp1ID] || !thePeopleList[sp2ID]) {
             return true;
         }
@@ -2657,7 +2668,9 @@
                 const spouseRecord = sp1Data.Spouses[spNum];
                 if (spouseRecord.Id == sp2ID) {
                     foundSpouse = true;
-                    if (
+                    if (sp1Data.Spouses[spNum].NotMarried == "1" ) {
+                            return true;
+                    } else if (
                         sp1Data.Spouses[spNum].NotMarried == "0" ||
                         
                         sp1Data.Spouses[spNum].DoNotDisplay == "0" ||
@@ -3639,7 +3652,11 @@
                             drawColour +
                             `" stroke-width="3" />`;
 
-                        equalsLine +=
+
+                        if (doNotDisplayMarriageEquals(primaryLeaf.Id, primarySpouseID)) {
+                            // do nothing
+                        } else {
+                            equalsLine +=
                             `<polyline points="` +
                             (maxX + (3 * boxWidth) / 2 + 20) +
                             "," +
@@ -3655,6 +3672,7 @@
                             `" fill="none" stroke="` +
                             drawColour +
                             `" stroke-width="3" />`;
+                        }
                     } 
                 } else {
                     if (currentSpNum > 3) {
@@ -3682,18 +3700,22 @@
                             drawColour +
                             `" stroke-width="3" />`;
 
-                        equalsLine +=
-                            `<polyline points="` +
-                            (minX - (3 * boxWidth) / 2 - 20) +
-                            "," +
-                            (primaryLeaf.y + 120 - currentSpNum) +
-                            " " +
-                            (minX + boxWidth / 4) +
-                            "," +
-                            (topEqualsY + 30) +
-                            `" fill="none" stroke="` +
-                            drawColour +
-                            `" stroke-width="3" />`;
+                         if (doNotDisplayMarriageEquals(primaryLeaf.Id, primarySpouseID)) {
+                            // do nothing
+                        } else {
+                            equalsLine +=
+                                `<polyline points="` +
+                                (minX - (3 * boxWidth) / 2 - 20) +
+                                "," +
+                                (primaryLeaf.y + 120 - currentSpNum) +
+                                " " +
+                                (minX + boxWidth / 4) +
+                                "," +
+                                (topEqualsY + 30) +
+                                `" fill="none" stroke="` +
+                                drawColour +
+                                `" stroke-width="3" />`;
+                        }
                     }
                 }
 
@@ -4759,7 +4781,7 @@
                 );
 
                 // FOR DEBUGGING PURPOSES HERE
-                if (1 == 1) {
+                if (1 == 2) {
                     let theOldProfiles = result[1];
                     for (const index in theOldProfiles) {
                         const theOldID = theOldProfiles[index].Id;
@@ -4777,14 +4799,33 @@
                 let numNewPeeps = 0;
                 let numNewSpouses = 0;
 
+                let basePrivateID = SuperBigFamView.nextPrivateId;
+
                 for (const index in theNewProfiles) {
                     numNewPeeps++;
-                    thePeopleList.addIfNeeded(theNewProfiles[index]);
+                    let thePerson = theNewProfiles[index];
+
+                    if (thePerson.Id < 0) {
+                        // thePerson.Id = 100 - thePerson.Id; // DO NOT RE-WRITE history and assign a small positive number - that could conflict with early WikiTree profiles, like Chris W's family, for example - GO HUGE !!!
+                        thePerson.Id = basePrivateID - thePerson.Id;
+                        SuperBigFamView.maxPrivateId = Math.max(SuperBigFamView.nextPrivateId, thePerson.Id) ;
+                        thePerson["Name"] = "Priv8-" + thePerson.Id;
+                        thePerson["FirstName"] = "Private";
+                        thePerson["LastNameAtBirth"] = "";
+                    }
+                    if (thePerson.Mother < 0) {
+                        thePerson.Mother = basePrivateID - thePerson.Mother;
+                    }
+                    if (thePerson.Father < 0) {
+                        thePerson.Father = basePrivateID - thePerson.Father;
+                    }
+
+                    thePeopleList.addIfNeeded(thePerson);
                     SuperBigFamView.ListsOfIDs[getCode + "out"].push(index);
 
-                    if (theNewProfiles[index].Spouses && theNewProfiles[index].Spouses.length > 0) {
-                        for (let s = 0; s < theNewProfiles[index].Spouses.length; s++) {
-                            const sp = theNewProfiles[index].Spouses[s];
+                    if (thePerson.Spouses && thePerson.Spouses.length > 0) {
+                        for (let s = 0; s < thePerson.Spouses.length; s++) {
+                            const sp = thePerson.Spouses[s];
                             SuperBigFamView.ListsOfIDs[getCode + "sp"].push(sp.Id);
                             numNewSpouses++;
                         }
@@ -4854,6 +4895,7 @@
     */
 
     function postGetPeopleProcessing(codeLetter, newLevel, doSift = false) {
+        SuperBigFamView.nextPrivateId = SuperBigFamView.maxPrivateId + 1;
         for (let peepID in thePeopleList) {
             let thisPeep = thePeopleList[peepID];
 
@@ -7501,7 +7543,7 @@
                 if (thePerson.Id < 0) {
                     // thePerson.Id = 100 - thePerson.Id; // DO NOT RE-WRITE history and assign a positive number - that could conflict with early WikiTree profiles, like Chris W's family, for example
                     thePerson.Id = basePrivateID - thePerson.Id; 
-                    SuperBigFamView.nextPrivateId = Math.min(SuperBigFamView.nextPrivateId, thePerson.Id);
+                    SuperBigFamView.maxPrivateId = Math.max(SuperBigFamView.nextPrivateId, thePerson.Id) ;
                     thePerson["Name"] = "Priv8-" +  thePerson.Id;
                     thePerson["FirstName"] = "Private";
                     thePerson["LastNameAtBirth"] = "";
@@ -8317,6 +8359,7 @@
         let thisRent = thePeopleList[parentID]; // Parent = RENT (using P for Partners)
         if (peepID < 0) {
             // return;  // NOT
+            // console.log("WARNING WARNING ---> peepID < 0 in linkParentAndChild :", peepID, parentID, parentType);
         }
         // condLog(
         //     thisRent._data.BirthNamePrivate,
@@ -8415,6 +8458,26 @@
     }
 
     function thisChildAlreadyInChildrenList(kidID, kidList) {
+        if (thePeopleList[kidID]._data.Name.indexOf("Priv8") > -1) {
+
+            let appMode = SuperBigFamView.numAncGens2Display + "|" + SuperBigFamView.numDescGens2Display + "|" + SuperBigFamView.numCuzGens2Display;
+            let parentComboKey = thePeopleList[kidID]._data.Father + "|" + thePeopleList[kidID]._data.Mother;
+            // console.log(
+            //     thePeopleList[kidID]._data.Name,
+            //     thePeopleList[kidID]._data.Father,
+            //     thePeopleList[kidID]._data.Mother,
+            //     appMode,
+            //     parentComboKey
+            // );
+            
+            if (SuperBigFamView.privateChildren2ParentsTracker[parentComboKey] && SuperBigFamView.privateChildren2ParentsTracker[parentComboKey] > "" && SuperBigFamView.privateChildren2ParentsTracker[parentComboKey] != appMode) {
+                return true;
+            } else {
+                SuperBigFamView.privateChildren2ParentsTracker[parentComboKey] = appMode;
+            }
+
+        }
+
         for (let C = 0; C < kidList.length; C++) {
             const kidObj = kidList[C];
             if (kidID == kidObj.Id) {

--- a/views/superBigFamTree/SuperBigFamView.js
+++ b/views/superBigFamTree/SuperBigFamView.js
@@ -7279,7 +7279,23 @@
             document.getElementById("PedigreeOnlyBtn").checked, SuperBigFamView.displayPedigreeOnly
         );
 
-        document.getElementById("PedigreeOnlyBtn").checked =  (SuperBigFamView.displayPedigreeOnly == 1);
+        if (document.getElementById("PedigreeOnlyBtn").checked) {
+            SuperBigFamView.displayPedigreeOnly = 1;
+        } else {
+            SuperBigFamView.displayPedigreeOnly = 0;
+
+        } 
+        if (document.getElementById("SiblingsBtnSVG").checked) {
+            SuperBigFamView.displaySIBLINGS = 1;
+        } else {
+            SuperBigFamView.displaySIBLINGS = 0;
+        } 
+        if (document.getElementById("InLawsBtnSVG").checked) {
+            SuperBigFamView.displayINLAWS = 1;
+        } else {
+            SuperBigFamView.displayINLAWS = 0;
+        } 
+
 
         
         // condLog("Now theAncestors = ", SuperBigFamView.theAncestors);
@@ -7506,6 +7522,10 @@
         SuperBigFamView.workingMaxNumAncGens = 3;
         SuperBigFamView.workingMaxNumDescGens = 2;
         SuperBigFamView.workingMaxNumCuzGens = 1;
+
+        SuperBigFamView.displayPedigreeOnly = 0;
+        SuperBigFamView.displaySIBLINGS = 1;
+        SuperBigFamView.displayINLAWS = 0;
 
         self._load(id).then(function (person) {
             // condLog("SuperBigFamView.prototype.load : self._load(id) ");

--- a/views/superBigFamTree/SuperBigFamView.js
+++ b/views/superBigFamTree/SuperBigFamView.js
@@ -3213,7 +3213,7 @@
     }
 
     function extraHeightForChunk(Chunk) {
-        if (!SuperBigFamView.theChunkCollection[Chunk].YsList) {
+        if (!SuperBigFamView.theChunkCollection[Chunk] || !SuperBigFamView.theChunkCollection[Chunk].YsList) {
             return 0;
         } else if (SuperBigFamView.theChunkCollection[Chunk].YsList.length < 2) {
             return 0;
@@ -4112,6 +4112,14 @@
             for (let dnd = 0; dnd< doNotDisplaySpousesList.length; dnd++) {
                 const dndSpouseID = doNotDisplaySpousesList[dnd];
              
+                // AVOID duplicate lines from Direct Ancestors
+                // --> Will draw the single parent family of the Direct Ancestor from one of his parents (e.g. A0RM w kidPrefix = "R")
+                // --> Would RE-DRAW the single parent family as a Sibling of Direct Ancestor (e.g. A0RMRM w kidPrefix = "A0RMS")
+                if (code.substr(-2)== "RM" && kidPrefix.substr(-1) == "S") {
+                    continue;
+                }
+
+
                 condLog(
                     "drawLinesForFamilyOf - DO NOT DISPLAY PARENT --> NEED TO ADD YOUR OWN FLAVOUR OF LINES : ",
                     code,
@@ -4121,6 +4129,7 @@
                 let drawColour = "orange";
                 if (dndSpouseID == -1) {
                     drawColour = "blue";
+                    console.log("drawLinesForFamilyOf", code, "*" + kidPrefix + "*", levelNum, clrNum, code.substr(-2), kidPrefix.substr(-3));
                 } else if (dndSpouseID == -2) {
                     drawColour = "deeppink";
                 }
@@ -5827,7 +5836,7 @@
             // STEP 1.5 : Do an initial pass of drawLines to figure out any extra heights needed because of crossing lines
             SuperBigFamView.drawLines;
             endisableButtons(false);
-            
+
             // STEP 2 : Position each cluster along the primary axis, left or right of it based on paternal vs maternal lines
             let thisY = 0;
             let cuzHeight = 0;


### PR DESCRIPTION
Another tweak ... Private Children were coming in twice, making families appear twice as large as they really were.

Also - fixed connectors between non-married people (single bar, instead of equal sign like double bar connector)

Note: If privacy level is such that marriages aren't returned by the API, then those marriages will by default look like single-barred connections.   No way currently to guess otherwise.

Current version: https://apps.wikitree.com/apps/clarke11007/WTdynamicTree/#view=superbig