### PR TITLE
CC7: Correct degree counts in presence of private profiles

### DIFF
--- a/views/cc7/js/cc7.js
+++ b/views/cc7/js/cc7.js
@@ -491,6 +491,7 @@ export class CC7 {
             CC7.firstTimeLoad = false;
             $("#getPeopleButton").prop("disabled", true);
             $("#getDegreeButton").prop("disabled", true);
+            $("#getExtraDegrees").prop("disabled", true);
             $("#cancelLoad").show();
             CC7.cancelLoadController = new AbortController();
             CC7.clearDisplay();
@@ -544,6 +545,7 @@ export class CC7 {
             }
             $("#getPeopleButton").prop("disabled", false);
             $("#getDegreeButton").prop("disabled", false);
+            $("#getExtraDegrees").prop("disabled", false);
             $("#cancelLoad").hide();
             CC7.setInfoPanelMessage();
         }
@@ -823,6 +825,7 @@ export class CC7 {
         const getExtra = document.getElementById("getExtraDegrees").checked;
         $("#getPeopleButton").prop("disabled", true);
         $("#getDegreeButton").prop("disabled", true);
+        $("#getExtraDegrees").prop("disabled", true);
         $("#cancelLoad").show();
         CC7.cancelLoadController = new AbortController();
         Utils.showShakingTree(CC7Utils.CC7_CONTAINER_ID);
@@ -898,6 +901,7 @@ export class CC7 {
         }
         $("#getPeopleButton").prop("disabled", false);
         $("#getDegreeButton").prop("disabled", false);
+        $("#getExtraDegrees").prop("disabled", false);
         $("#cancelLoad").hide();
         CC7.setInfoPanelMessage();
         CC7.firstTimeLoad = false;

--- a/views/cc7/js/cc7.js
+++ b/views/cc7/js/cc7.js
@@ -880,7 +880,7 @@ export class CC7 {
                         "<tr id='trCon'><th>Connections</th></tr>" +
                         "<tr id='trTot'><th>Total</th></tr>" +
                         '</table><p id="ancReport">' +
-                        (haveRoot
+                        (haveRoot && nrDirectAncestors > 0
                             ? `Out of ${maxDirectAncestors} possible direct ancestors in ${
                                   maxRequestedDeg + 2
                               } generations, ${nrDirectAncestors} (${(
@@ -1393,14 +1393,14 @@ export class CC7 {
     static buildDegreeTableData(degreeCounts, fromDegree) {
         function addTableCol(i, degreeSum) {
             $("#trDeg").append($(`<td>${i}</td>`));
-            $("#trCon").append($(`<td>${degreeCounts[i]}</td>`));
+            $("#trCon").append($(`<td>${degreeCounts[i] || "?"}</td>`));
             if (fromDegree == 1) {
-                $("#trTot").append($(`<td>${degreeSum}</td>`));
+                $("#trTot").append($(`<td>${degreeSum || "?"}</td>`));
             }
         }
         let degreeSum = 0;
         for (let i = fromDegree; i <= window.cc7Degree; ++i) {
-            degreeSum = degreeSum + degreeCounts[i];
+            degreeSum = degreeSum + (degreeCounts[i] || 0);
             addTableCol(i, degreeSum);
         }
         if (degreeCounts[-1]) {


### PR DESCRIPTION
Private profiles may cause no profiles to be present for a given degree (typically degree 1 and 2). This caused degree counts to be displayed as NaN. Now it (and the total if necessary) will be displayed as ?.

The new behaviour can be tested at https://apps.wikitree.com/apps/smit641/cc7/#name=Wimble-157&view=cc7