### PR TITLE
Update view handling in tree.js to support URL parameters

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,7 +52,7 @@ Before you start check [WikiTree codestyle](/docs/codestyle.md) and optionally s
 
         `[class based]` Create descendant of View class and override method
 
-        `meta`: use you own title, description and docs
+        `meta`: use you own title, description, docs, and accept parameters
 
         `init`: use your own implementation of view
 
@@ -70,10 +70,11 @@ Before you start check [WikiTree codestyle](/docs/codestyle.md) and optionally s
                     description: "",
                     // link pointing at some webpage with documentation
                     docs: "",
+                    params: ["param1", "param2"]
                 };
             }
 
-            init(container_selector, person_id) {
+            init(container_selector, person_id, params) {
                 // do whathever you want there
                 // to showcase your awesome view, e.g.
                 document.querySelector(
@@ -93,7 +94,7 @@ Before you start check [WikiTree codestyle](/docs/codestyle.md) and optionally s
 
         alternativelly, you can create those fields directly in constructor, e.g.: this.title = "Template view"
 
-1. link your new script file in `<head>` section of the `index.html` and register your new view in `ViewRegistry` in index.js, e.g.
+2. link your new script file in `<head>` section of the `index.html` and register your new view in `ViewRegistry` in index.js, e.g.
 
     ```js
     new ViewRegistry(

--- a/views/familyPortraits/portraits.js
+++ b/views/familyPortraits/portraits.js
@@ -6,10 +6,17 @@ window.PortraitView = class PortraitView extends View {
             title: "Family Portraits",
             description: `Generate a photo gallery that displays portraits of ancestors. Click an image to visit the profile.`,
             docs: "",
+            params: ["ancestors", "siblings"]
         };
     }
 
-    init(selector, person_id) {
+    init(selector, person_id, params) {
+        console.log(params);
+
+        const ancestors = params.ancestors || 10;
+        const validSiblings = (siblings) => ['1', '0'].includes(siblings) ? siblings : '1';
+        const siblings = validSiblings(params.siblings);
+
         var pageNumber = 0;
         getPages(pageNumber);
 
@@ -19,8 +26,8 @@ window.PortraitView = class PortraitView extends View {
                 appId: PortraitView.APP_ID,
                 action: "getPeople",
                 keys: person_id,
-                ancestors: 10,
-                siblings: 1,
+                ancestors: ancestors,
+                siblings: siblings,
                 fields: "Name,PhotoData",
                 limit: 1000,
                 start: pageNumber


### PR DESCRIPTION
View handling has been updated in `tree.js` to allow for passing additional parameters through the URL. The parameters are extracted from the URL, filtered based on what each view specifies in its meta().params, and then passed along when the view is initialized. This ensures that only parameters explicitly documented in the view's meta() are used, which keeps things clean and prevents unwanted data from being passed to views.

Within a view, parameters are defined and accepted in the view meta:

```
meta() {
   return {
      title: "MyNewView",
      description: `Mew view description`,
      docs: "https://www.WikiTree.com/wiki/Space:MyNewView",
      params: ["param1", "param2"]
   };
}
```

The parameters can then be used in the init:

```
init(selector, person_id, params) {
   console.log(params.param1);
   console.log(params.param2);
}
```