### PR TITLE
Add AbortController

### DIFF
--- a/views/familyPortraits/portraits.js
+++ b/views/familyPortraits/portraits.js
@@ -1,6 +1,11 @@
 window.PortraitView = class PortraitView extends View {
     static APP_ID = "Portraits";
 
+    constructor() {
+        super();
+        this.abortController = new AbortController();
+    }
+
     meta() {
         return {
             title: "Family Portraits",
@@ -10,112 +15,109 @@ window.PortraitView = class PortraitView extends View {
         };
     }
 
+    close() {
+        if (this.abortController) {
+            this.abortController.abort();
+            console.log('API processing halted.');
+        }
+        $('#view-options').remove();
+    }
+
     init(selector, person_id, params) {
-        console.log(params);
+        this.abortController = new AbortController();
 
         const ancestors = params.ancestors || 10;
         const validSiblings = (siblings) => ['1', '0'].includes(siblings) ? siblings : '1';
         const siblings = validSiblings(params.siblings);
 
         var pageNumber = 0;
-        getPages(pageNumber);
+        this.getPages(pageNumber, selector, person_id, ancestors, siblings);
+    }
 
-        function getPages(pageNumber) {
-            console.log(`getPages: Page Number ${pageNumber}`)
-            WikiTreeAPI.postToAPI({
-                appId: PortraitView.APP_ID,
-                action: "getPeople",
-                keys: person_id,
-                ancestors: ancestors,
-                siblings: siblings,
-                fields: "Name,PhotoData",
-                limit: 1000,
-                start: pageNumber
-            }).then(function (data) {
-                // Define an error message for permission denial.
-                const errorMessage = "Ancestor/Descendant permission denied.";
+    getPages(pageNumber, selector, person_id, ancestors, siblings) {
+        WikiTreeAPI.postToAPI({
+            appId: PortraitView.APP_ID,
+            action: "getPeople",
+            keys: person_id,
+            ancestors: ancestors,
+            siblings: siblings,
+            fields: "Name,PhotoData",
+            limit: 1000,
+            start: pageNumber,
+            signal: this.abortController.signal // Use the signal to allow aborting
+        }).then((data) => {
+            if (this.abortController.signal.aborted) {
+                console.log('Request was aborted. Stopping further processing.');
+                return;
+            }
 
-                // Check if the API response contains the permission error.
-                if (
-                    data[0].resultByKey &&
-                    data[0].resultByKey[person_id] &&
-                    data[0].resultByKey[person_id].status === errorMessage
-                ) {
-                    // If permission denied, display an error message.
-                    let err = `The starting profile data could not be retrieved.`;
-                    if (wtViewRegistry?.session.lm.user.isLoggedIn()) {
-                        err += ` You may need to be added to the starting profile's Trusted List.`;
-                    } else {
-                        err += ` Try the Apps login.`;
-                    }
-                    wtViewRegistry.showError(err);
-
-                    // Hide the info panel.
-                    wtViewRegistry.hideInfoPanel();
+            const errorMessage = "Ancestor/Descendant permission denied.";
+            if (
+                data[0].resultByKey &&
+                data[0].resultByKey[person_id] &&
+                data[0].resultByKey[person_id].status === errorMessage
+            ) {
+                let err = `The starting profile data could not be retrieved.`;
+                if (wtViewRegistry?.session.lm.user.isLoggedIn()) {
+                    err += ` You may need to be added to the starting profile's Trusted List.`;
                 } else {
-                    const photoDataList = [];
-                    const galleryContainer = $(selector);
+                    err += ` Try the Apps login.`;
+                }
+                wtViewRegistry.showError(err);
+                wtViewRegistry.hideInfoPanel();
+            } else {
+                const photoDataList = [];
+                const galleryContainer = $(selector);
+                const newGalleryDiv = $('<div id="photo-gallery"></div>');
 
-                    // Create a new div element for the photo gallery.
-                    const newGalleryDiv = $('<div id="photo-gallery"></div>');
+                for (const key in data[0].people) {
+                    if (data[0].people.hasOwnProperty(key)) {
+                        const person = data[0].people[key];
+                        const name = person.Name;
+                        const url = person.PhotoData ? person.PhotoData.url : null;
+                        const path = person.PhotoData ? person.PhotoData.path : null;
+                        const origWidth = person.PhotoData ? person.PhotoData.orig_width : null;
+                        const origHeight = person.PhotoData ? person.PhotoData.orig_height : null;
 
-                    // Extract Names and PhotoData information.
-                    for (const key in data[0].people) {
-                        if (data[0].people.hasOwnProperty(key)) {
-                            const person = data[0].people[key];
-                            const name = person.Name;
-                            const url = person.PhotoData ? person.PhotoData.url : null;
-                            const path = person.PhotoData ? person.PhotoData.path : null;
-                            const origWidth = person.PhotoData ? person.PhotoData.orig_width : null;
-                            const origHeight = person.PhotoData ? person.PhotoData.orig_height : null;
+                        if (name && url && origWidth && origHeight) {
+                            const aspectRatio = origWidth / origHeight;
 
-                            if (name && url && origWidth && origHeight) {
-                                // Calculate the aspect ratio of the image.
-                                const aspectRatio = origWidth / origHeight;
-
-                                // Check if the original width is greater than or equal to 301 pixels.
-                                if (origWidth >= 301) {
-                                    // If the aspect ratio is less than or equal to 10.0,
-                                    // construct a new 300px URL and add it to the photoDataList.
-                                    if (aspectRatio <= 10.0) {
-                                        const new300pxUrl = url.replace('/75px-', '/300px-');
-                                        photoDataList.push({ name, url: new300pxUrl });
-                                    }
-                                } else {
-                                    // If the original width is less than 301 pixels,
-                                    // and the path does not include 'pdf,' add the full-size path to the photoDataList.
-                                    if (!path.includes('pdf')) {
-                                        photoDataList.push({ name, path });
-                                    }
+                            if (origWidth >= 301) {
+                                if (aspectRatio <= 10.0) {
+                                    const new300pxUrl = url.replace('/75px-', '/300px-');
+                                    photoDataList.push({ name, url: new300pxUrl });
+                                }
+                            } else {
+                                if (!path.includes('pdf')) {
+                                    photoDataList.push({ name, path });
                                 }
                             }
                         }
                     }
+                }
 
-                    // Verify the gallery container element exists.
-                    if (galleryContainer) {
-                        // Generate HTML for the photo gallery using the data in photoDataList.
-                        const galleryHTML = photoDataList.map((data) => `
+                if (galleryContainer) {
+                    const galleryHTML = photoDataList.map((data) => `
                         <a href="https://www.wikitree.com/wiki/${data.name}" target="_blank">
                             <img class="portrait-gallery-image" src="https://www.wikitree.com${data.url || data.path}" alt="${data.name}" />
                         </a>
                     `).join('');
-
-                        // Add the gallery HTML to the newGalleryDiv.
-                        newGalleryDiv.html(galleryHTML);
-
-                        // Append the newGalleryDiv to the galleryContainer.
-                        galleryContainer.append(newGalleryDiv);
-                    }
-                    // Count the number of people in the data
-                    var numPeople = Object.keys(data[0].people).length;
-                    console.log(`Page Number ${pageNumber}, ${numPeople} people`);
-                    if (numPeople === 1000) {
-                        pageNumber += 1000;
-                        getPages(pageNumber);
-                    }
+                    newGalleryDiv.html(galleryHTML);
+                    galleryContainer.append(newGalleryDiv);
                 }
-            });
-        }
+
+                var numPeople = Object.keys(data[0].people).length;
+                if (numPeople === 1000) {
+                    pageNumber += 1000;
+                    this.getPages(pageNumber, selector, person_id, ancestors, siblings);
+                }
+            }
+        }).catch((error) => {
+            if (error.name === 'AbortError') {
+                console.log('API request was aborted.');
+            } else {
+                console.error('Error fetching data:', error);
+            }
+        });
     }
 };


### PR DESCRIPTION
Added an AbortController to stop API requests when the view closes. Re-initializing the view creates a new AbortController, allowing it to work after being closed. The close method now cancels ongoing requests and prevents further processing. Added a check to ensure no data is processed after a request is aborted, ensuring the view can stop and restart properly.

Fixes Issue #185 