### PR TITLE
Reset state properly when closing a view

### DIFF
--- a/views/ahnentafel/ahnentafel.js
+++ b/views/ahnentafel/ahnentafel.js
@@ -33,7 +33,7 @@ window.AhnentafelView = class AhnentafelView extends View {
     close() {
         $("#moreGenerationsButton").off("click").remove();
         $("header #ahnentafelHeaderBox").remove();
-        $("#view-container").css({ "min-height": "1000px", "overflow": "visible" });
+        $("#view-container").css({ "min-height": "", "overflow": "" });
         $("#view-container").removeClass("ahnentafelView");
         $(document).off("keydown.AhnentafelView");
         $("#view-container").off();

--- a/views/cc7/cc7View.js
+++ b/views/cc7/cc7View.js
@@ -20,7 +20,9 @@ window.CC7View = class CC7View extends View {
         // However, init() can be called multiple times while the view is active (i.e. everytime the GO button is clicked)
         // so we save the overflow value only if close() had been called since we last saved it
         if (!this.overflow) {
-            this.overflow = $("#view-container").css("overflow");
+            // Note this can't be done with the JQuery css() function as that returns evaluated style.
+            // We want only the value from the "style" attribute (which should be null)
+            this.overflow = document.querySelector("#view-container").style.overflow || "";   // not $("#view-container").css("overflow");
         }
         const cc7 = new CC7(container_selector, person_id);
     }

--- a/views/couplesTree/couples_tree.js
+++ b/views/couplesTree/couples_tree.js
@@ -31,6 +31,7 @@ import { Utils } from "../shared/Utils.js";
 
 window.CouplesTreeView = class CouplesTreeView extends View {
     static #DESCRIPTION = "Click on the question mark in the green circle below right for help.";
+    #container;
     constructor() {
         super();
         CachedPerson.init(new PeopleCache(new CacheLoader()));
@@ -49,7 +50,12 @@ window.CouplesTreeView = class CouplesTreeView extends View {
         // this.#peopleCache.clear();
         wtViewRegistry.setInfoPanel(CouplesTreeView.#DESCRIPTION);
         wtViewRegistry.showInfoPanel();
+        this.#container = document.querySelector(container_selector);
         new CouplesTreeViewer(container_selector).loadAndDraw(person_id);
+    }
+
+    close() {
+        this.#container.classList.remove("cvtc");
     }
 };
 

--- a/views/descendants/descendants.js
+++ b/views/descendants/descendants.js
@@ -9,7 +9,7 @@ window.DescendantsView = class DescendantsView extends View {
 
     close() {
         // Another view is about to be activated, retore the original overflow value of view-container
-        $("#view-container").css("overflow", "auto");
+        $("#view-container").css("overflow", "");
         $("body").removeClass("descendants");
 
         function removeEventListeners() {

--- a/views/oneNameTrees/oneNameTrees.js
+++ b/views/oneNameTrees/oneNameTrees.js
@@ -2887,6 +2887,9 @@ window.OneNameTrees = class OneNameTrees extends View {
     }
 
     completeDisplay() {
+        if (!document.body.classList.contains("oneNameTrees")) {
+            return; // If we are no longer the active view, do nothing
+        }
         // If this.displayedIndividuals (set) is empty, create it by getting all the IDs from the HTML
         if (this.displayedIndividuals.size === 0) {
             $("li.person").each((index, person) => {

--- a/views/superBigFamTree/SuperBigFamView.js
+++ b/views/superBigFamTree/SuperBigFamView.js
@@ -937,9 +937,17 @@ import { WTapps_Utils } from "../fanChart/WTapps_Utils.js";
              //     theCookieSettings["general_options_badgeLabels_otherValue"];
          };
 
+    SuperBigFamView.prototype.close = function () {
+        this.container.style.height = null;
+        let infoPanel = document.getElementById("info-panel");
+        infoPanel.parentNode.classList.remove("stickyDIV");
+        infoPanel.parentNode.style.padding = null;
+    };
+
     SuperBigFamView.prototype.init = function (selector, startId) {
         // condLog("SuperBigFamView.js - line:18", selector) ;
         var container = document.querySelector(selector);
+        this.container = container; // store this for teardown later
 
         container.style.height = "100vh";
 

--- a/views/timeline/TimelineView.js
+++ b/views/timeline/TimelineView.js
@@ -9,6 +9,12 @@ window.TimelineView = class TimelineView extends View {
         };
     }
 
+    close() {
+        const container = document.getElementById("view-container");
+        container.style.width = null;
+        container.style.position = null;
+    }
+
     init(selector, person_id) {
         WikiTreeAPI.postToAPI({
             appId: TimelineView.APP_ID,


### PR DESCRIPTION
While working on SlippyTree I did some testing swapping between various views, and found quite a few of them didn't clean up after themselves properly when closed. This PR fixes all the ones I found - I've broken it down into one checkin for each view so they can be cherry picked if that's preferred.

The main issues were classes or style rules being added to `view-container` and either not being removed afterwards, or being replaced with some sort of  *default* value, eg `auto`. As any values set with `style` are going to override anything in the CSS stylesheets, style properties added have to be removed, not just set to `auto`.

To see why this is needed, try loading first (eg) Family Timeline and then changing to another view - you'll see there are still style rules set on the `view-container`. Switch from Family Timeline to SlippyTree and you'll see a double horizontal scrollbar because of a style rule left on `view-container` by Family Timeline. 

The correct way to fix this is for each view to completely clean up after itself which is what this PR will fix.

I also caught oneNameTree's callback continuing to run when I triggered a load and then quickly changed view - that's fixed here too.


