### PR TITLE
CC7: Handle IDs that include spaces and/or are not capitalised

### DIFF
--- a/views/cc7/js/PeopleTable.js
+++ b/views/cc7/js/PeopleTable.js
@@ -32,7 +32,7 @@ export class PeopleTable {
         $("#savePeople").show();
         // Set root person if it is not already set
         if (window.rootPerson) {
-            if (window.rootPerson?.Name != $("#wt-id-text").val()) {
+            if (window.rootPerson?.Name != Utils.getTreeAppWtId()) {
                 window.rootPerson = false;
             }
         }

--- a/views/cc7/js/cc7.js
+++ b/views/cc7/js/cc7.js
@@ -917,7 +917,7 @@ export class CC7 {
     }
 
     static addRelationships() {
-        const rootName = $("#wt-id-text").val().trim();
+        const rootName = Utils.getTreeAppWtId();
         let rootId = null;
         const familyMapEntries = [];
         for (let [key, value] of window.people.entries()) {
@@ -1485,7 +1485,7 @@ export class CC7 {
                     [
                         window.rootId,
                         window.cc7Degree,
-                        $(wtViewRegistry.WT_ID_TEXT).val(),
+                        Utils.getTreeAppWtId(),
                         $(`#${CC7Utils.CC7_CONTAINER_ID}`).hasClass("degreeView"),
                     ],
                     ...window.people.entries(),

--- a/views/shared/Utils.js
+++ b/views/shared/Utils.js
@@ -1,4 +1,15 @@
 export class Utils {
+    /**
+     * @returns The WikiTree ID of the profile entered in the field next to the Tree APP id.
+     *          Leading and trailing spaces are removed all remaining spaces are replaced
+     *          with underscores and the first letter capitalised to ensure that the result
+     *          will match the profile.Name field returned for that id by the APIs.
+     */
+    static getTreeAppWtId() {
+        const id = $(wtViewRegistry.WT_ID_TEXT).val().trim().replaceAll(" ", "_");
+        return id ? id.charAt(0).toUpperCase() + id.slice(1) : id;
+    }
+
     static getCookie(name) {
         return WikiTreeAPI.cookie(name) || null;
     }


### PR DESCRIPTION
The TreeApps WT ID field may contain spaces (e.g. "St. Claire-3") and it is immaterial whether the first letter is capitalised or not, the profile will still be found. However, in the Name field being returned, the first letter is always capitalised and all spaces are replaces with underscores. This code ensures the CC7 Views app take that into account.

There is now a shared/Utils function that will return the entered field in its standard form.

This can be tested at https://apps.wikitree.com/apps/smit641/cc7/#name=st.%20Claire-3&view=cc7 (where relationships are being filled in) while at https://www.wikitree.com/apps/St.%20Claire-3#name=st.%20Claire-3&view=cc7 they are not.