### PR TITLE
Couples Tree: Fix no spouse bug

### DIFF
--- a/views/couplesTree/cached_person.js
+++ b/views/couplesTree/cached_person.js
@@ -371,7 +371,7 @@ export class CachedPerson {
         return this._data.Spouses && this._data.PreferredSpouseId;
     }
     hasNoSpouse() {
-        return this._data.Spouses && this._data.noMoreSpouses && this._data.Spouses.length == 0;
+        return this._data.Spouses && this._data.noMoreSpouses && this._data.Spouses.size == 0;
     }
     setPreferredSpouse(id) {
         if (this.hasSpouse(id)) {
@@ -379,7 +379,7 @@ export class CachedPerson {
             // also change the preferred spouse of the preferred spouse if possible
             const thisId = this.getId();
             const spouse = this.getSpouse();
-            if (spouse._data.preferredSpouse != thisId && spouse._data.Spouses && spouse._data.Spouses[thisId]) {
+            if (spouse._data.preferredSpouse != thisId && spouse._data.Spouses && spouse._data.Spouses.has(thisId)) {
                 spouse._data.preferredSpouse = thisId;
             }
             return true;


### PR DESCRIPTION
The bug prevented a node consisting of a single person with "no spouse" set, to be displayed as a single person.

This can be tested at https://apps.wikitree.com/apps/smit641/dynamic-tree/#name=Fogelman-50&view=couples