### PR TITLE
Fix Safari bug

### DIFF
--- a/views/cc7/js/PeopleTable.js
+++ b/views/cc7/js/PeopleTable.js
@@ -1206,7 +1206,7 @@ class PeopleTable {
         $("#cc7DegFilter").select2({
             placeholder: "Type a number or select a symbol",
             tags: true, // Allow custom input
-            data: [...shapeOptions.entries().map((opt) => ({ id: opt[0], title: opt[1].title }))],
+            data: [...shapeOptions.entries()].map((opt) => ({ id: opt[0], title: opt[1].title })),
             templateResult: formatDegOption,
             templateSelection: formatDegOption,
             // dropdownParent: $("#cc7Container"),


### PR DESCRIPTION
Safari does not support .map on an iterator, resulting in filters in CC7 Views not working. This fixes that.

This can be tested (using Safari) at https://apps.wikitree.com/apps/smit641/cc7/#view=cc7