### PR TITLE
SlippyTree sizing is more robust

### DIFF
--- a/views/slippyTree/script.js
+++ b/views/slippyTree/script.js
@@ -1193,11 +1193,8 @@ class SlippyTree extends View {
             // Re-add edges, people, labels in priority order
             for (const person of ordered) {
                 if (isNaN(person.tx) || isNaN(person.ty)) throw new Error("Person="+person+" g="+person.generation+" tx="+person.tx+" ty="+person.ty);
-                if (typeof person.x != "number") {
-                    person.x = person.tx;
-                }
-                if (typeof person.y != "number") {
-                    person.y = person.ty;
+                if (typeof person.x != "number" || typeof person.y != "number") {
+                    person.x = person.y = 0;        // INITIAL POSITION: from center
                 }
             }
             if (this.browser) {
@@ -1217,11 +1214,8 @@ class SlippyTree extends View {
                 let focusedges = [];
                 for (const person of ordered) {
                     if (isNaN(person.tx) || isNaN(person.ty)) throw new Error("Person="+person+" g="+person.generation+" tx="+person.tx+" ty="+person.ty);
-                    if (typeof person.x != "number") {
-                        person.x = person.tx;
-                    }
-                    if (typeof person.y != "number") {
-                        person.y = person.ty;
+                    if (typeof person.x != "number" || typeof person.y != "number") {
+                        person.x = person.y = 0;        // INITIAL POSITION: from center
                     }
                     peoplepane.appendChild(person.svg);
                 }

--- a/views/slippyTree/script.js
+++ b/views/slippyTree/script.js
@@ -2245,7 +2245,7 @@ class SlippyTree extends View {
             }
         };
 
-        if (WikiTreeAPI && WikiTreeAPI.postToAPI) {
+        if (typeof WikiTreeAPI != "undefined" && WikiTreeAPI.postToAPI) {
             // We need to send "token" and do a POST on the live site, apparently.
             // Tap into WikiTreeAPI for this to future-proof for any other requirements.
             if (this.debug) console.log("Load " + JSON.stringify(usedparams));

--- a/views/slippyTree/style.css
+++ b/views/slippyTree/style.css
@@ -24,7 +24,7 @@ body > #view-container:has(> .slippy-tree-container) {
  * fill it, and b) it will never be dependent on the size of its children.
  * With that done, the view-container can be sized any way we like.
  */
-* > .slippy-tree-container {
+:has(> .slippy-tree-container) {
     position: relative;
 }
 .slippy-tree-container {

--- a/views/slippyTree/style.css
+++ b/views/slippyTree/style.css
@@ -12,23 +12,32 @@ body:has(.slippy-tree-container) {
     flex-direction: column;
     height: 100%;
 }
-#view-container:has(.slippy-tree-container) {
+body > #view-container:has(> .slippy-tree-container) {
     flex: 1;
     min-height: auto;
 }
 
 /**
- * Below here everything is prefixed with .slippy-tree-container
+ * Below here everything is prefixed with .slippy-tree-container.
+ * The next rule and the pos:absolute are to ensure that whatever the size
+ * of the thing that contains slippy-tree-container, a) the container will
+ * fill it, and b) it will never be dependent on the size of its children.
+ * With that done, the view-container can be sized any way we like.
  */
-.slippy-tree-container {
+* > .slippy-tree-container {
     position: relative;
+}
+.slippy-tree-container {
+    position: absolute;
+    width: 100%;
+    height: 100%;
     font: 14px sans-serif;
     overflow: hidden;
-    height: 100%;
     --button-color: #639;
 }
 .slippy-tree-container * {
     touch-action: none !important;
+    box-sizing: initial;        /* Bootstrap is so toxic */
 }
 .slippy-tree-container h1 {
     font-size: 16px;
@@ -68,6 +77,7 @@ body:has(.slippy-tree-container) {
     align-items: center;
     z-index: 9999;
     left: 20px;
+    text-decoration: none;
 }
 .slippy-tree-container .slippy-help-button::before {
     content: "?";


### PR DESCRIPTION
Adjust the sizing algorithm for SlippyTree so that it will expand to to fill whatever space it has been given and *not* rely on how that space was created. Makes no difference in trunk, but stops an infinite series of resize operations in (eg) dev-2025.

