### PR TITLE
Fan Chart - CSS tweak to avoid Safari/iOS chaos! / ESCAPE key popup dismissal

### DIFF
--- a/css/wt-components.css
+++ b/css/wt-components.css
@@ -333,6 +333,9 @@ ul.views li.current {
   padding: 15px;
   position: relative;
 }
+.staticPosition {
+  position: static;
+}
 
 .box p {
   margin-bottom: 0;

--- a/views/ancestorLines/api.js
+++ b/views/ancestorLines/api.js
@@ -31,6 +31,9 @@ export class API {
         "Privacy",
         "RealName",
         "Suffix",
+
+        "Spouse", // added for Person Popups
+        "PhotoData"
     ];
 
     static FOR_BIO_CHECK = ["Bio", "IsMember", "Manager"];

--- a/views/cc7/js/CirclesView.js
+++ b/views/cc7/js/CirclesView.js
@@ -45,12 +45,12 @@ export class CirclesView {
         console.log("CIRCLES VIEW - buildView");
 
         var popupDIV =
-            '<div id=popupDIV style="display:none; position:absolute; left:20px; background-color:#EFEFEF; border: solid darkgrey 4px; border-radius: 15px; padding: 15px;}">' +
+            '<div id=popupDIV class="pop-up" style="display:none; position:absolute; left:20px; background-color:#EFEFEF; border: solid darkgrey 4px; border-radius: 15px; padding: 15px;}">' +
             '<span style="color:red; align:left"><A onclick="SuperBigFamView.removePopup();">' +
             SVGbtnCLOSE +
             "</A></span></div>";
         var connectionPodDIV =
-            '<div id=connectionPodDIV style="display:none; width:fit-content; position:absolute; left:700px; background-color:#EFEFEF; border: solid darkgrey 4px; border-radius: 15px; padding: 15px;}">' +
+            '<div id=connectionPodDIV class="pop-up" style="display:none; width:fit-content; position:absolute; left:700px; background-color:#EFEFEF; border: solid darkgrey 4px; border-radius: 15px; padding: 15px;}">' +
             '<span style="color:red; align:left"><A onclick="SuperBigFamView.removePodDIV();">' +
             SVGbtnCLOSE +
             "</A></span></div>";
@@ -61,11 +61,11 @@ export class CirclesView {
         <div id="circlesDisplay">
             <div id=circlesBtnBar style='background-color: #f8a51d80; align: center; width="100%"' >
             Display: 
-                <label><input type=radio   name=circlesDisplayType id=displayType_dot value=dot > <font color=magenta>&#x2B24;</font></label> &nbsp;&nbsp;
+                <label><input type=radio   name=circlesDisplayType id=displayType_dot value=dot checked> <font color=magenta>&#x2B24;</font></label> &nbsp;&nbsp;
                 <label><input type=radio   name=circlesDisplayType id=displayType_ltr value=ltr> A</label> &nbsp;&nbsp;
                 <label><input type=radio   name=circlesDisplayType id=displayType_inits value=inits> ABC</label> &nbsp;&nbsp;
                 <label><input type=radio   name=circlesDisplayType id=displayType_fName value=fName > FName </label> &nbsp;&nbsp;
-                <label><input type=radio   name=circlesDisplayType id=displayType_all value=all checked> all  </label>
+                <label><input type=radio   name=circlesDisplayType id=displayType_all value=all > all  </label>
                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  <label id=fillCirclesLabel><input type=checkbox id="displayType_filled" checked> Fill circles</label>
                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  <label id=fillCirclesLabel><input type=checkbox id="displayType_BandW" > Black & White</label>
             </div>
@@ -661,7 +661,7 @@ export class CirclesView {
         // let displayType = "dot";
         console.log({ degreeCount });
         let circleTypeVariables = {
-            dot: { dotRadius: 4 },
+            dot: { dotRadius: 9 },
             ltr: { dotRadius: 9 },
             inits: { dotRadius: 18 },
             fName: { dotRadius: 18 },
@@ -817,7 +817,7 @@ export class CirclesView {
                 numInThisRing = 0;
                 desiredNumThisRing = numCirclesPerRing[currentRingNum];
                 if (desiredNumThisRing > 0){ 
-                    currentRadiusMultipler += radiusMultipler - CirclesView.dotRadius;
+                    currentRadiusMultipler += radiusMultipler - CirclesView.dotRadius + 3;
                     // thisRingNum--;
                 }
                 condLog("RING " + currentRingNum + " for CC" + degree, { currentRadiusMultipler }, {desiredNumThisRing});
@@ -901,6 +901,7 @@ export class CirclesView {
                     leafCollection: CirclesView.theLeafCollection,
                     peopleList : CirclesView.PersonCodesObject,
                     appID: "cc7",
+                    SettingsObj : Settings
                 });
 
                 console.log("CirclesView.personPopup");

--- a/views/fanChart/FanChartView.js
+++ b/views/fanChart/FanChartView.js
@@ -44,6 +44,8 @@ import { Utils } from "../shared/Utils.js";
         // console.log(theCookie);
     });
 
+    var firstFanChartPopUpPopped = false ;
+
     const PRINTER_ICON = "&#x1F4BE;";
     const SETTINGS_GEAR = "&#x2699;";
     const LEGEND_CLIPBOARD = "&#x1F4CB;";
@@ -1297,8 +1299,8 @@ import { Utils } from "../shared/Utils.js";
             "<div id=highlightDescriptor><br/><span class='fontBold selectedMenuBarOption'>HIGHLIGHT people</span> = <span id=highlightPeepsDescriptor>Thirty-somethings...</span><br/><br/></div>";
 
         var legendHTML =
-            '<div id=legendDIV style="display:none; position:absolute; left:20px; background-color:#EDEADE; border: solid darkgreen 4px; border-radius: 15px; padding: 15px;}">' +
-            `<span style="color:red; position:absolute; top:0.2em; left:0.6em; cursor:pointer;"><a onclick="FanChartView.hideLegend();">` +
+            '<div id=legendDIV class="pop-up" style="display:none; position:absolute; left:20px; background-color:#EDEADE; border: solid darkgreen 4px; border-radius: 15px; padding: 15px; z-index:9999}">' +
+            `<span style="color:red; position:absolute; top:-0.2em; left:0em; cursor:pointer;"><a onclick="FanChartView.hideLegend();">` +
             SVGbtnCLOSE +
             "</a></span>" +
             highlightHTML +
@@ -1307,7 +1309,7 @@ import { Utils } from "../shared/Utils.js";
             "</div>";
 
         var aboutHTML =
-            '<div id=aboutDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px;}">' +
+            '<div id=aboutDIV class="pop-up" style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px; zIndex:9999}">' +
             `<span style="color:red; position:absolute; top:0.2em; right:0.6em; cursor:pointer;"><a onclick="FanChartView.toggleAbout();">` +
             SVGbtnCLOSE +
             "</a></span>" +
@@ -1346,15 +1348,64 @@ import { Utils } from "../shared/Utils.js";
         var saveSettingsChangesButton = document.getElementById("saveSettingsChanges");
         saveSettingsChangesButton.addEventListener("click", (e) => settingsChanged(e));
 
-         $("#popupDIV").draggable();
-         $("#connectionPodDIV").draggable();
+        $("#popupDIV").draggable();
+        $("#connectionPodDIV").draggable();
+        $("#legendDIV").draggable();
+        document.getElementById("legendDIV").style.zIndex = Utils.getNextZLevel();
+
+        //   $("#popupDIV").keyup(function (e) {
+        //       if (e.keyCode == 13) {
+        //         console.log("POPUP DIV  / KEY CODE 13 !!!")
+        //         //   $("#drawTreeButton").click();
+        //       }
+        //   });
+
+        $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+
+        FanChartView.closeTopPopup = function (e) {
+            console.log("closeTopPopUp");
+                if (e.key === "Escape") {
+                    // Find the popup with the highest z-index
+                    console.log("ESCAPE KEY in FanChartView / document");
+                    const [lastPopup, highestZIndex] = FanChartView.findTopPopup();
+        
+                    // Close the popup with the highest z-index
+                    if (lastPopup) {
+                        // FanChartView.closePopup(lastPopup);
+                        console.log("GOING to SLIDE UP the Fan Chart lastPopup")
+                        lastPopup.slideUp("fast");
+                        Utils.setNextZLevel(highestZIndex);
+                    }
+                }
+            }
+            
+        FanChartView.findTopPopup = function () {
+            console.log("findTopPopup");
+            // Find the popup with the highest z-index
+            let highestZIndex = 0;
+            let lastPopup = null;
+            $(".pop-up:visible").each(function () {
+                const zIndex = parseInt($(this).css("z-index"), 10);
+                if (zIndex > highestZIndex) {
+                    highestZIndex = zIndex;
+                    lastPopup = $(this);
+                }
+            });
+            return [lastPopup, highestZIndex];
+        }
 
         FanChartView.toggleAbout = function () {
             let aboutDIV = document.getElementById("aboutDIV");
             let settingsDIV = document.getElementById("settingsDIV");
+            if (!Utils.firstTreeAppPopUpPopped) {
+                $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+                Utils.firstTreeAppPopUpPopped = true;
+            } 
+
             if (aboutDIV) {
                 if (aboutDIV.style.display == "none") {
                     aboutDIV.style.display = "block";
+                    aboutDIV.style.zIndex = Utils.getNextZLevel();
                     settingsDIV.style.display = "none";
                 } else {
                     aboutDIV.style.display = "none";
@@ -2405,7 +2456,7 @@ import { Utils } from "../shared/Utils.js";
     }
 
     FanChartView.updateLegendIfNeeded = function () {
-        // console.log("DOING updateLegendIfNeeded");
+        console.log("DOING updateLegendIfNeeded - now", APP_ID);
         let settingForColourBy = FanChartView.currentSettings["colour_options_colourBy"];
         let settingForSpecifyByFamily = FanChartView.currentSettings["colour_options_specifyByFamily"];
         let settingForSpecifyByLocation = FanChartView.currentSettings["colour_options_specifyByLocation"];
@@ -2691,6 +2742,13 @@ import { Utils } from "../shared/Utils.js";
                 // );
             }
         }
+        if (document.getElementById("legendDIV").style.display == "block") {
+            document.getElementById("legendASCII").style.display = "inline-block";
+            if (!Utils.firstTreeAppPopUpPopped) {
+                $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+                Utils.firstTreeAppPopUpPopped = true;
+            } 
+        }    
     };
 
     function reverseCommaArray(arr, addSpace = false) {
@@ -2922,10 +2980,16 @@ import { Utils } from "../shared/Utils.js";
         // condLog(FanChartView.fanchartSettingsOptionsObject.getDefaultOptions());
         let theDIV = document.getElementById("settingsDIV");
         condLog("SETTINGS ARE:", theDIV.style.display);
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        } 
+
         if (theDIV.style.display == "none") {
             theDIV.style.display = "block";
             let aboutDIV = document.getElementById("aboutDIV");
             aboutDIV.style.display = "none";
+            theDIV.style.zIndex = Utils.getNextZLevel();
         } else {
             theDIV.style.display = "none";
         }
@@ -2935,8 +2999,13 @@ import { Utils } from "../shared/Utils.js";
         // condLog(FanChartView.fanchartSettingsOptionsObject.getDefaultOptions());
         let theDIV = document.getElementById("legendDIV");
         condLog("SETTINGS ARE:", theDIV.style.display);
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
         if (theDIV.style.display == "none") {
             theDIV.style.display = "block";
+            theDIV.style.zIndex = Utils.getNextZLevel();
         } else {
             theDIV.style.display = "none";
         }
@@ -3552,9 +3621,9 @@ import { Utils } from "../shared/Utils.js";
         nodeEnter
             .append("foreignObject")
             .attrs({
-                id: "foreignObj4",
+                // id: "foreignObj" + ancestorObject.ahnNum,
                 width: boxWidth,
-                height: 0.01, // the foreignObject won't display in Firefox if it is 0 height
+                height: boxHeight, // the foreignObject won't display in Firefox if it is 0 height
                 x: -boxWidth / 2,
                 y: -boxHeight / 2,
             })
@@ -3621,7 +3690,7 @@ import { Utils } from "../shared/Utils.js";
                     return `
                         <div  id=wedgeBoxFor${
                             ancestorObject.ahnNum
-                        } class="box" style="background-color: ${theClr} ; border:0; padding: 0px;">
+                        } class="box staticPosition" style="background-color: ${theClr} ; border:0; padding: 0px;">
                         <div class="name fontBold font${font4Name}"    id=nameDivFor${
                         ancestorObject.ahnNum
                     } style="font-size: 10px;" >${getShortName(person)}</div>
@@ -3631,7 +3700,7 @@ import { Utils } from "../shared/Utils.js";
                     return `
                         <div  id=wedgeBoxFor${
                             ancestorObject.ahnNum
-                        } class="box" style="background-color: ${theClr} ; border:0; padding: 0px;">
+                        } class="box staticPosition" style="background-color: ${theClr} ; border:0; padding: 0px;">
                         <div class="name fontBold font${font4Name}"   id=nameDivFor${
                         ancestorObject.ahnNum
                     }  style="font-size: 14px;" >${getShortName(person)}</div>
@@ -3642,7 +3711,7 @@ import { Utils } from "../shared/Utils.js";
                     return `
                         <div  id=wedgeBoxFor${
                             ancestorObject.ahnNum
-                        } class="box" style="background-color: ${theClr} ; border:0; padding: 3px;">
+                        } class="box staticPosition" style="background-color: ${theClr} ; border:0; padding: 3px;">
                         <span  id=extraInfoFor${ancestorObject.ahnNum}>${extraInfoForThisAnc}${extraBR}</span>
                         <div class="name fontBold font${font4Name}"  id=nameDivFor${
                         ancestorObject.ahnNum
@@ -3764,7 +3833,7 @@ import { Utils } from "../shared/Utils.js";
                     return `
                     <div  id=wedgeBoxFor${
                         ancestorObject.ahnNum
-                    } class="box" style="background-color: ${theClr} ; border:0; ">
+                    } class="box staticPosition" style="background-color: ${theClr} ; border:0; ">
                     <span  id=extraInfoFor${ancestorObject.ahnNum}>${extraInfoForThisAnc}${extraBR}</span>
                     ${photoDiv}
                     <div class="name centered fontBold font${font4Name}" id=nameDivFor${
@@ -3802,7 +3871,7 @@ import { Utils } from "../shared/Utils.js";
                     if (theClr == "none") {
                         theClr = "#00000000";
                     }
-                    return `<div class="box centered" id=wedgeInfoFor${
+                    return `<div class="box staticPosition centered" id=wedgeInfoFor${
                         ancestorObject.ahnNum
                     } style="background-color: ${theClr} ; border:0; ">
                      <span  id=extraInfoFor${ancestorObject.ahnNum}>${extraInfoForThisAnc}${extraBR}</span>
@@ -4493,11 +4562,18 @@ import { Utils } from "../shared/Utils.js";
      */
     Tree.prototype.personPopup  = function (person) {
         console.log("POP UP : person = ",person);
+        // console.log({ firstFanChartPopUpPopped });
+        // console.log("Utils.firstTreeAppPopUpPopped", Utils.firstTreeAppPopUpPopped);
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        } 
         personPopup.popupHTML(person, {
             type: "Ahn",
             ahNum: FanChartView.myAhnentafel.listByPerson[person._data.Id]  ,
             primaryPerson: thePeopleList[FanChartView.myAhnentafel.list[1]],
-            myAhnentafel: FanChartView.myAhnentafel
+            myAhnentafel: FanChartView.myAhnentafel,
+            SettingsObj : Utils
         });
         console.log("FanChartView.personPopup");
     };
@@ -8156,4 +8232,7 @@ import { Utils } from "../shared/Utils.js";
     //     // condLog("FanChartView.removeBadges function : ", badgeType);
     //     d3.selectAll(".badge" + badgeType).remove();
     // };
+
+    $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
 })();
+

--- a/views/fanChart/FanChartView.js
+++ b/views/fanChart/FanChartView.js
@@ -1363,16 +1363,16 @@ import { Utils } from "../shared/Utils.js";
         $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
 
         FanChartView.closeTopPopup = function (e) {
-            console.log("closeTopPopUp");
+            // console.log("closeTopPopUp");
                 if (e.key === "Escape") {
                     // Find the popup with the highest z-index
-                    console.log("ESCAPE KEY in FanChartView / document");
+                    // console.log("ESCAPE KEY in FanChartView / document");
                     const [lastPopup, highestZIndex] = FanChartView.findTopPopup();
         
                     // Close the popup with the highest z-index
                     if (lastPopup) {
                         // FanChartView.closePopup(lastPopup);
-                        console.log("GOING to SLIDE UP the Fan Chart lastPopup")
+                        // console.log("GOING to SLIDE UP the Fan Chart lastPopup")
                         lastPopup.slideUp("fast");
                         Utils.setNextZLevel(highestZIndex);
                     }
@@ -1380,7 +1380,7 @@ import { Utils } from "../shared/Utils.js";
             }
             
         FanChartView.findTopPopup = function () {
-            console.log("findTopPopup");
+            // console.log("findTopPopup");
             // Find the popup with the highest z-index
             let highestZIndex = 0;
             let lastPopup = null;
@@ -2456,7 +2456,7 @@ import { Utils } from "../shared/Utils.js";
     }
 
     FanChartView.updateLegendIfNeeded = function () {
-        console.log("DOING updateLegendIfNeeded - now", APP_ID);
+        // console.log("DOING updateLegendIfNeeded - now", APP_ID);
         let settingForColourBy = FanChartView.currentSettings["colour_options_colourBy"];
         let settingForSpecifyByFamily = FanChartView.currentSettings["colour_options_specifyByFamily"];
         let settingForSpecifyByLocation = FanChartView.currentSettings["colour_options_specifyByLocation"];
@@ -4561,7 +4561,7 @@ import { Utils } from "../shared/Utils.js";
      * Show a popup for the person.
      */
     Tree.prototype.personPopup  = function (person) {
-        console.log("POP UP : person = ",person);
+        // console.log("POP UP : person = ",person);
         // console.log({ firstFanChartPopUpPopped });
         // console.log("Utils.firstTreeAppPopUpPopped", Utils.firstTreeAppPopUpPopped);
         if (!Utils.firstTreeAppPopUpPopped) {
@@ -4575,7 +4575,7 @@ import { Utils } from "../shared/Utils.js";
             myAhnentafel: FanChartView.myAhnentafel,
             SettingsObj : Utils
         });
-        console.log("FanChartView.personPopup");
+        // console.log("FanChartView.personPopup");
     };
     
     

--- a/views/fanChart/SettingsOptions.js
+++ b/views/fanChart/SettingsOptions.js
@@ -56,6 +56,17 @@ window.SettingsOptions = window.SettingsOptions || {};
         
 
 */
+
+ nextZLevel = 10000;
+
+    function getNextZLevel() {
+        return ++nextZLevel;
+    }
+
+    function setNextZLevel(n) {
+        nextZLevel = n;
+    }
+
 function compareSettings(currentSettings) {
     // console.log("Compare as you dare:");
     // console.log(currentSettings);
@@ -357,7 +368,7 @@ SettingsOptions.SettingsOptionsObject = class SettingsOptionsObject {
         // ORIGINAL FILL COLOUR AT END OF PATH:  #292D32
 
         let theDIVhtml =
-            '<div id=settingsDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid darkgreen 4px; border-radius: 15px; padding: 15px;}">' +
+            '<div id=settingsDIV class="pop-up" style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid darkgreen 4px; border-radius: 15px; padding: 15px; zIndex:9999;}">' +
             '<span style="color:red; position:absolute; top:-0.2em; right:-0.0em; cursor:pointer;"><A onclick="' +
             data.viewClassName +
             '.cancelSettings();">' +

--- a/views/fanChart/personPopup.js
+++ b/views/fanChart/personPopup.js
@@ -13,15 +13,42 @@
 window.personPopup = window.personPopup || {};
 
 let connectObject = {};
+let currentPersonPopupID = 0;
+let currentConnectionPopupID = 0;
+
 // Returns an array [x , y] that corresponds to the endpoint of rθ from (centreX,centreY)
 personPopup.popupHTML = function (person, connectionObj = {}, appIcon = "", appView = "") {
     console.log("Popup for ", person, connectionObj);
     connectObject = connectionObj;
 
-    let thisPopup = document.getElementById("popupDIV");
-    thisPopup.style.display = "block";
+    let personData = person._data;
+    if (!personData) {
+        personData = person;
+        condLog(thePeopleList);
+    }
 
+    
+    let thisPopup = document.getElementById("popupDIV");
+    // IF we have just clicked the cell to "display" the current popup, and it's already open, then we should shut it down
+    if (thisPopup.style.display == "block" && currentPersonPopupID == personData.Id) {        
+        $("#popupDIV").slideUp("fast");
+        currentPersonPopupID = 0;
+        return;
+    }
+    // else ... make it visible by changing it to "block"
+    thisPopup.style.display = "block";
+    
+    currentPersonPopupID = personData.Id;
     thisPopup.classList.add("popup");
+    thisPopup.classList.add("pop-up");
+
+    thisPopup.style.zIndex = 9998; // give a default zIndex, in case there is no SettingsObj defined ...
+    if (connectObject.SettingsObj) {
+        // but, if there IS one, then use it to assign a new zIndex.
+        // console.log("FOUND Settings to get next z level", thisPopup.style.zIndex);
+        thisPopup.style.zIndex = connectObject.SettingsObj.getNextZLevel();
+        console.log("CHANGED next z level", thisPopup.style.zIndex);
+    }
 
     let displayName4Popup = person.getDisplayName();
     var photoUrl = person.getPhotoUrl(75),
@@ -51,11 +78,7 @@ personPopup.popupHTML = function (person, connectionObj = {}, appIcon = "", appV
     }
 
 
-    let personData = person._data;
-    if (!personData) {
-        personData = person;
-        condLog(thePeopleList);
-    }
+   
 
 
     let extrasAtBottom =
@@ -225,14 +248,14 @@ personPopup.popupHTML = function (person, connectionObj = {}, appIcon = "", appV
         SVGbtnCLOSE +
         `</a></span>
                     <div class="image-box"><img src="https://www.wikitree.com/${photoUrl}">
-                    <br/><br/><A onclick=popupConnectionDIV()><img style="height:24px; cursor:pointer;" src="https://dev-2025.wikitree.com/images/icons/icon-connect.svg"></A>
+                    <br/><br/><A onclick=popupConnectionDIV() title="View how this person is connected to the Primary Person in this Tree"><img style="height:24px; cursor:pointer;" src="https://dev-2025.wikitree.com/images/icons/icon-connect.svg"></A>
                     </div>
                     <div class="vital-info">
                         <div class="name">
                         <a href="https://www.wikitree.com/wiki/${person.getName()}" target="_blank">${displayName4Popup}</a>
-                        <span class="tree-links"><a href="#name=${person.getName()}&view=fanchart"><img style="width:45px; height:30px;" src="https://apps.wikitree.com/apps/clarke11007/pix/fan180.png" /></a></span>
-                        <span class="tree-links"><a href="#name=${person.getName()}&view=descendants">${SVGbtnDESC}</a></span>
-                        <span class="tree-links"><a href="#name=${person.getName()}&view=superbig"><img style="width:45px; height:30px;" src="https://apps.wikitree.com/apps/clarke11007/pix/SuperBigFamTree.png" /></a></span>
+                        <span class="tree-links"><a href="#name=${person.getName()}&view=fanchart" title="View this person's Ancestors in a Fan Chart"><img style="width:45px; height:30px;" src="https://apps.wikitree.com/apps/clarke11007/pix/fan180.png" /></a></span>
+                        <span class="tree-links"><a href="#name=${person.getName()}&view=descendants" title="View this person's Descendants list">${SVGbtnDESC}</a></span>
+                        <span class="tree-links"><a href="#name=${person.getName()}&view=superbig"  title="View this person's Super (big family) Tree"><img style="width:45px; height:30px;" src="https://apps.wikitree.com/apps/clarke11007/pix/SuperBigFamTree.png" /></a></span>
                         </div>
                         <div class="birth vital">${birthString(person)}</div>
                         <div class="death vital">${deathString(person)}</div>						  
@@ -294,9 +317,28 @@ function popupConnectionDIV() {
     condLog("POP UP - Connection SVG pod !");
 
     let thisPopup = document.getElementById("connectionPodDIV");
+
+    if (currentConnectionPopupID == currentPersonPopupID) {
+        $("#connectionPodDIV").slideUp("fast");
+        currentConnectionPopupID = 0;
+        return;
+    }
+
+    currentConnectionPopupID = currentPersonPopupID;
+
     thisPopup.style.display = "block";
 
-    thisPopup.classList.add("popup");
+    // thisPopup.classList.add("popup");
+    thisPopup.classList.add("pop-up");
+    thisPopup.style.zIndex = 9999;
+
+    if (connectObject.SettingsObj) {
+        // console.log("CONNECTIONS POD: FOUND Settings to get next z level", thisPopup.style.zIndex);
+        thisPopup.style.zIndex = connectObject.SettingsObj.getNextZLevel();
+        // console.log("CONNECTIONS POD: CHANGED next z level", thisPopup.style.zIndex);
+    }
+
+    
     condLog("See anything??", connectObject);
 
     let popupHTML =

--- a/views/fanChart/personPopup.js
+++ b/views/fanChart/personPopup.js
@@ -18,7 +18,7 @@ let currentConnectionPopupID = 0;
 
 // Returns an array [x , y] that corresponds to the endpoint of rθ from (centreX,centreY)
 personPopup.popupHTML = function (person, connectionObj = {}, appIcon = "", appView = "") {
-    console.log("Popup for ", person, connectionObj);
+    // condLog("Popup for ", person, connectionObj);
     connectObject = connectionObj;
 
     let personData = person._data;
@@ -45,9 +45,9 @@ personPopup.popupHTML = function (person, connectionObj = {}, appIcon = "", appV
     thisPopup.style.zIndex = 9998; // give a default zIndex, in case there is no SettingsObj defined ...
     if (connectObject.SettingsObj) {
         // but, if there IS one, then use it to assign a new zIndex.
-        // console.log("FOUND Settings to get next z level", thisPopup.style.zIndex);
+        // condLog("FOUND Settings to get next z level", thisPopup.style.zIndex);
         thisPopup.style.zIndex = connectObject.SettingsObj.getNextZLevel();
-        console.log("CHANGED next z level", thisPopup.style.zIndex);
+        // condLog("CHANGED next z level", thisPopup.style.zIndex);
     }
 
     let displayName4Popup = person.getDisplayName();
@@ -208,20 +208,21 @@ personPopup.popupHTML = function (person, connectionObj = {}, appIcon = "", appV
                     if (marriageDate > "" || marriagePlace > "") {
                         // marriageInfo += "<br/>m. ";
                         if (marriageDate > "") {
-                            prepMarriageInfo += ", " + marriageDate;
-                        }
-                        // if (marriageDate > "" && marriagePlace > "") {
-                        //     prepMarriageInfo += ", ";
-                        // }
-                        if (marriagePlace > "") {
-                            prepMarriageInfo += ", " + marriagePlace;
+                            prepMarriageInfo +=
+                                ", <span class='marriage vital'>m. <strong>" + humanDate(marriageDate) + "</strong>";
+                            if (marriagePlace > "") {
+                                prepMarriageInfo += " in " + marriagePlace;
+                            }
+                            prepMarriageInfo += "</span>";
+                        } else if (marriagePlace > "") {
+                            prepMarriageInfo += ", <span class='marriage vital'>m. " + marriagePlace + "</span>";
                         }
                     }
 
                     // if (numSpousesListed > 0 && spID > 0) {
-                    marriageInfo += "<br/>m. ";
+                    // marriageInfo += "<br/>m. ";
                     // }
-                    marriageInfo += prepMarriageInfo;
+                    marriageInfo += "<br/>" + prepMarriageInfo;
                     numSpousesListed++;
                 }
             }
@@ -333,9 +334,9 @@ function popupConnectionDIV() {
     thisPopup.style.zIndex = 9999;
 
     if (connectObject.SettingsObj) {
-        // console.log("CONNECTIONS POD: FOUND Settings to get next z level", thisPopup.style.zIndex);
+        // condLog("CONNECTIONS POD: FOUND Settings to get next z level", thisPopup.style.zIndex);
         thisPopup.style.zIndex = connectObject.SettingsObj.getNextZLevel();
-        // console.log("CONNECTIONS POD: CHANGED next z level", thisPopup.style.zIndex);
+        // condLog("CONNECTIONS POD: CHANGED next z level", thisPopup.style.zIndex);
     }
 
     
@@ -479,15 +480,15 @@ function popupConnectionDIV() {
         if (connectObject.appID == "SuperBigTree") {
             codesList = connectObject.person._data.CodesList;
         } else if (connectObject.appID == "cc7") {
-            console.log(connectObject.person);
+            // condLog(connectObject.person);
             if (!connectObject.person._data) {
-                console.log("NO DATA OBJECT !!!!");
+                // condLog("NO DATA OBJECT !!!!");
                 popupHTML +=
                     "Cannot draw this Connection Path at this time.<BR><BR>Possible reasons:<BR> * Private profile in between start and end of path<BR> * Not logged into the Apps Server<BR> * Displaying Degree Only";
                 thisPopup.innerHTML = popupHTML;
 
             } else if (!connectObject.person._data.CodesList) {
-                console.log("MISSING CODES LIST - ", connectObject.person);
+                // condLog("MISSING CODES LIST - ", connectObject.person);
                 codesList = ["A0"]
             } else {
                 codesList = connectObject.person._data.CodesList;
@@ -1166,6 +1167,6 @@ function popupConnectionDIV() {
   */
 function copyDataText(widget) {
      navigator.clipboard.writeText(widget.getAttribute("data-copy-text"));
-     // console.log("copyDataText:", widget, widget.getAttribute("data-copy-text"));
+     // condLog("copyDataText:", widget, widget.getAttribute("data-copy-text"));
  };
 

--- a/views/fandoku/FandokuView.js
+++ b/views/fandoku/FandokuView.js
@@ -2586,7 +2586,7 @@ import { Utils } from "../shared/Utils.js";
             AboutAppIcon, 
             "fandoku");
             
-        console.log("FandokuView.personPopup");
+        // console.log("FandokuView.personPopup");
     };
     
     

--- a/views/fandoku/FandokuView.js
+++ b/views/fandoku/FandokuView.js
@@ -638,11 +638,11 @@ import { Utils } from "../shared/Utils.js";
         var btnBarHTML =
             '<div id=btnBarDIV><table border=0 style="background-color: #f8a51d80;" width="100%"><tr>' +
             '<td width="30%" style="padding-left:10px;">' +
-            "<button id=startGameButton style='padding: 5px' onclick='FandokuView.startGame();'>Start Game</button>" +
+            "<button class='btn btn-primary' id=startGameButton style='padding: 5px' onclick='FandokuView.startGame();'>Start Game</button>" +
             "<span id=preGameFans>" +
-            '<A onclick="FandokuView.maxAngle = 360; FandokuView.redraw();"><img height=20px src="https://apps.wikitree.com/apps/clarke11007/pix/fan360.png" /></A> |' +
-            ' <A onclick="FandokuView.maxAngle = 240; FandokuView.redraw();"><img height=20px src="https://apps.wikitree.com/apps/clarke11007/pix/fan240.png" /></A> |' +
-            ' <A onclick="FandokuView.maxAngle = 180; FandokuView.redraw();"><img height=20px src="https://apps.wikitree.com/apps/clarke11007/pix/fan180.png" /></A>' +
+            '<A onclick="FandokuView.maxAngle = 360; FandokuView.redraw();"><img  style="height:30px;"  src="https://apps.wikitree.com/apps/clarke11007/pix/fan360.png" /></A> |' +
+            ' <A onclick="FandokuView.maxAngle = 240; FandokuView.redraw();"><img  style="height:30px;"  src="https://apps.wikitree.com/apps/clarke11007/pix/fan240.png" /></A> |' +
+            ' <A onclick="FandokuView.maxAngle = 180; FandokuView.redraw();"><img  style="height:30px;"  src="https://apps.wikitree.com/apps/clarke11007/pix/fan180.png" /></A>' +
             "</span>" +
             "<span id=gameTimer style='display:none'>0:00</span>" +
             "</td>" +
@@ -661,8 +661,8 @@ import { Utils } from "../shared/Utils.js";
             "</td>" +
             '<td width="5%" id=loadingTD align="center" style="font-style:italic; color:blue">&nbsp;</td>' +
             '<td width="30%" align="right"  style="padding-right:10px;">' +
-            "<button id=resetGameButton style='padding: 5px; display:none;'  onclick='FandokuView.resetGame();'>Play Again</button>" +
-            "<button id=endGameButton style='padding: 5px; display:none;'  onclick='FandokuView.endGame();'>End Game</button>" +
+            "<button  class='btn btn-primary' id=resetGameButton style='padding: 5px; display:none;'  onclick='FandokuView.resetGame();'>Play Again</button>" +
+            "<button  class='btn btn-secondary' id=endGameButton style='padding: 5px; display:none;'  onclick='FandokuView.endGame();'>End Game</button>" +
             ' <A onclick="FandokuView.toggleSettings();"><font size=+2>' +
             SVGbtnSETTINGS +
             "</font></A>&nbsp;&nbsp;" +
@@ -677,7 +677,7 @@ import { Utils } from "../shared/Utils.js";
             '<DIV id=FeedbackArea style="text-align:center; background-color:papayawhip;">Feedback and Directions and Encouragement will go here</DIV>';
 
         var aboutHTML =
-            '<div id=aboutDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px;}">' +
+            '<div id=aboutDIV class="pop-up" style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px; zIndex:9999}">' +
             `<span style="color:red; position:absolute; top:0.2em; right:0.6em; cursor:pointer;"><a onclick="FandokuView.toggleAbout();">` +
             SVGbtnCLOSE +
             "</a></span>" +
@@ -754,9 +754,14 @@ import { Utils } from "../shared/Utils.js";
         FandokuView.toggleAbout = function () {
             let aboutDIV = document.getElementById("aboutDIV");
             let settingsDIV = document.getElementById("settingsDIV");
+            if (!Utils.firstTreeAppPopUpPopped) {
+                $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+                Utils.firstTreeAppPopUpPopped = true;
+            }
             if (aboutDIV) {
                 if (aboutDIV.style.display == "none") {
                     aboutDIV.style.display = "block";
+                    aboutDIV.style.zIndex = Utils.getNextZLevel();
                     settingsDIV.style.display = "none";
                 } else {
                     aboutDIV.style.display = "none";
@@ -1909,10 +1914,15 @@ import { Utils } from "../shared/Utils.js";
         condLog(FandokuView.fanchartSettingsOptionsObject.getDefaultOptions());
         let theDIV = document.getElementById("settingsDIV");
         condLog("SETTINGS ARE:", theDIV.style.display);
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
         if (theDIV.style.display == "none") {
             theDIV.style.display = "block";
             let aboutDIV = document.getElementById("aboutDIV");
             aboutDIV.style.display = "none";
+            theDIV.style.zIndex = Utils.getNextZLevel();
         } else {
             theDIV.style.display = "none";
         }
@@ -2267,7 +2277,7 @@ import { Utils } from "../shared/Utils.js";
                     return `
                     <div  id=wedgeBoxFor${
                         ancestorObject.ahnNum
-                    } class="box" style="background-color: ${theClr} ; border:0; ">
+                    } class="box staticPosition" style="background-color: ${theClr} ; border:0; ">
                     ${photoDiv}
                     <div class="name centered" id=nameDivFor${ancestorObject.ahnNum}><B>${getSettingsName(
                         person
@@ -2562,11 +2572,16 @@ import { Utils } from "../shared/Utils.js";
      * Show a popup for the person.
      */
     Tree.prototype.personPopup  = function (person) {
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
         personPopup.popupHTML(person, {
             type: "Ahn",
             ahNum: FandokuView.myAhnentafel.listByPerson[person._data.Id]  ,
             primaryPerson: thePeopleList[FandokuView.myAhnentafel.list[1]],
-            myAhnentafel: FandokuView.myAhnentafel
+            myAhnentafel: FandokuView.myAhnentafel,
+            SettingsObj : Utils
             }, 
             AboutAppIcon, 
             "fandoku");

--- a/views/fractalTree/FractalView.js
+++ b/views/fractalTree/FractalView.js
@@ -1199,7 +1199,7 @@ import { Utils } from "../shared/Utils.js";
             '</tr></table><DIV id=WarningMessageBelowButtonBar style="text-align:center; background-color:yellow;">Please wait while initial Fractal Tree is loading ...</DIV>';
 
         var aboutHTML =
-            '<div id=aboutDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px;}">' +
+            '<div id=aboutDIV class="pop-up" style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px; zIndex:9999}">' +
             `<span style="color:red; position:absolute; top:0.2em; right:0.6em; cursor:pointer;"><a onclick="FractalView.toggleAbout();">` +
             SVGbtnCLOSE +
             "</a></span>" +
@@ -1279,9 +1279,14 @@ import { Utils } from "../shared/Utils.js";
         FractalView.toggleAbout = function () {
             let aboutDIV = document.getElementById("aboutDIV");
             let settingsDIV = document.getElementById("settingsDIV");
+            if (!Utils.firstTreeAppPopUpPopped) {
+                $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+                Utils.firstTreeAppPopUpPopped = true;
+            }
             if (aboutDIV) {
                 if (aboutDIV.style.display == "none") {
                     aboutDIV.style.display = "block";
+                    aboutDIV.style.zIndex = Utils.getNextZLevel();
                     settingsDIV.style.display = "none";
                 } else {
                     aboutDIV.style.display = "none";
@@ -2615,10 +2620,15 @@ import { Utils } from "../shared/Utils.js";
         condLog(FractalView.fractalSettingsOptionsObject.getDefaultOptions());
         let theDIV = document.getElementById("settingsDIV");
         condLog("SETTINGS ARE:", theDIV.style.display);
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
         if (theDIV.style.display == "none") {
             theDIV.style.display = "block";
             let aboutDIV = document.getElementById("aboutDIV");
             aboutDIV.style.display = "none";
+            theDIV.style.zIndex = Utils.getNextZLevel();
         } else {
             theDIV.style.display = "none";
         }
@@ -2629,6 +2639,10 @@ import { Utils } from "../shared/Utils.js";
         // condLog(FractalView.fanchartSettingsOptionsObject.getDefaultOptions());
         let theDIV = document.getElementById("legendDIV");
         // condLog("SETTINGS ARE:", theDIV.style.display);
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
         if (theDIV.style.display == "none") {
             theDIV.style.display = "block";
         } else {
@@ -3506,7 +3520,11 @@ import { Utils } from "../shared/Utils.js";
      * Show a popup for the person.
      */
     Tree.prototype.personPopup  = function (person) {
-        
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
+
             personPopup.popupHTML(
                 person,
                 {
@@ -3514,6 +3532,7 @@ import { Utils } from "../shared/Utils.js";
                     ahNum: FractalView.myAhnentafel.listByPerson[person._data.Id],
                     primaryPerson: thePeopleList[FractalView.myAhnentafel.list[1]],
                     myAhnentafel: FractalView.myAhnentafel,
+                    SettingsObj : Utils
                 },
                 AboutAppIcon,
                 "fractal"

--- a/views/fractalTree/FractalView.js
+++ b/views/fractalTree/FractalView.js
@@ -1476,7 +1476,7 @@ import { Utils } from "../shared/Utils.js";
             let innerLegend = document.getElementById("innerLegend");
             let BRbetweenLegendAndStickers = document.getElementById("BRbetweenLegendAndStickers");
 
-            console.log("BOX WIDTH - ", newBoxWidth, "vs", boxWidth);
+            // console.log("BOX WIDTH - ", newBoxWidth, "vs", boxWidth);
             if (newBoxWidth && newBoxWidth > 0 && newBoxWidth != boxWidth) {
                 boxWidth = newBoxWidth;
                 nodeWidth = boxWidth * 1.5;
@@ -3537,7 +3537,7 @@ import { Utils } from "../shared/Utils.js";
                 AboutAppIcon,
                 "fractal"
             );
-        console.log("FractalView.personPopup");
+        // console.log("FractalView.personPopup");
     };
     
     

--- a/views/shared/Utils.js
+++ b/views/shared/Utils.js
@@ -45,15 +45,15 @@ export class Utils {
     }
 
     static closeTopPopup(e) {
-            console.log("closeTopPopUp");
+            condLog("closeTopPopUp");
                 if (e.key === "Escape") {
                     // Find the popup with the highest z-index
-                    console.log("ESCAPE KEY in UTILS / document");
+                    condLog("ESCAPE KEY in UTILS / document");
                     const [lastPopup, highestZIndex] = Utils.findTopPopup();
         
                     // Close the popup with the highest z-index
                     if (lastPopup) {                        
-                        console.log("GOING to SLIDE UP the Fan Chart lastPopup")
+                        condLog("GOING to SLIDE UP the Fan Chart lastPopup")
                         lastPopup.slideUp("fast");
                         setNextZLevel(highestZIndex);
                     }
@@ -61,7 +61,7 @@ export class Utils {
             }
             
     static findTopPopup() {
-            console.log("findTopPopup");
+            condLog("findTopPopup");
             // Find the popup with the highest z-index
             let highestZIndex = 0;
             let lastPopup = null;

--- a/views/shared/Utils.js
+++ b/views/shared/Utils.js
@@ -23,6 +23,59 @@ export class Utils {
     }
 
     /**
+     * Variables and Functions to deal with PopUps and rolling them up via ESCAPE key
+     * 
+     * based on logic from CC7Views, implemented to work in other Tree Apps
+     * 
+     * variable: #nextZLevel keeps track of the Z level of the most recent (highest) popup
+     * using getNextZlevel and setNextZLevel functions
+     * 
+     * 
+     * 
+     */
+    static #nextZLevel = 99999;
+    static firstTreeAppPopUpPopped = false ;
+
+    static getNextZLevel() {
+        return ++Utils.#nextZLevel;
+    }
+
+    static setNextZLevel(n) {
+        Utils.#nextZLevel = n;
+    }
+
+    static closeTopPopup(e) {
+            console.log("closeTopPopUp");
+                if (e.key === "Escape") {
+                    // Find the popup with the highest z-index
+                    console.log("ESCAPE KEY in UTILS / document");
+                    const [lastPopup, highestZIndex] = Utils.findTopPopup();
+        
+                    // Close the popup with the highest z-index
+                    if (lastPopup) {                        
+                        console.log("GOING to SLIDE UP the Fan Chart lastPopup")
+                        lastPopup.slideUp("fast");
+                        setNextZLevel(highestZIndex);
+                    }
+                }
+            }
+            
+    static findTopPopup() {
+            console.log("findTopPopup");
+            // Find the popup with the highest z-index
+            let highestZIndex = 0;
+            let lastPopup = null;
+            $(".pop-up:visible").each(function () {
+                const zIndex = parseInt($(this).css("z-index"), 10);
+                if (zIndex > highestZIndex) {
+                    highestZIndex = zIndex;
+                    lastPopup = $(this);
+                }
+            });
+            return [lastPopup, highestZIndex];
+        }
+
+    /**
      * Append a gif of a shaking tree as an image with id 'tree' to the HTML element with the id given in containerId
      * if 'tree' element does not exist. Otherwise, show the image using the jQuery slieDown() method.
      * @param {*} containerId (Optional, default="view-container") The element to which the image should

--- a/views/superBigFamTree/SuperBigFamView.js
+++ b/views/superBigFamTree/SuperBigFamView.js
@@ -1674,7 +1674,7 @@ import { Utils } from "../shared/Utils.js";
             '<DIV id=WarningMessageBelowButtonBar style="text-align:center; background-color:yellow;">Please wait while initial Super Big Family Tree is loading ...</DIV>';
 
         var aboutHTML =
-            '<div id=aboutDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px;}">' +
+            '<div id=aboutDIV class="pop-up" style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px; zIndex:9999}">' +
             `<span style="color:red; position:absolute; top:0.2em; right:0.6em; cursor:pointer;"><a onclick="SuperBigFamView.toggleAbout();">` +
             SVGbtnCLOSE +
             "</a></span>" +
@@ -1767,9 +1767,14 @@ import { Utils } from "../shared/Utils.js";
         SuperBigFamView.toggleAbout = function () {
             let aboutDIV = document.getElementById("aboutDIV");
             let settingsDIV = document.getElementById("settingsDIV");
+            if (!Utils.firstTreeAppPopUpPopped) {
+                $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+                Utils.firstTreeAppPopUpPopped = true;
+            }
             if (aboutDIV) {
                 if (aboutDIV.style.display == "none") {
                     aboutDIV.style.display = "block";
+                    aboutDIV.style.zIndex = Utils.getNextZLevel();
                     settingsDIV.style.display = "none";
                 } else {
                     aboutDIV.style.display = "none";
@@ -8574,8 +8579,13 @@ import { Utils } from "../shared/Utils.js";
         condLog(SuperBigFamView.SBFtreeSettingsOptionsObject.getDefaultOptions());
         let theDIV = document.getElementById("settingsDIV");
         condLog("SETTINGS ARE:", theDIV.style.display);
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
         if (theDIV.style.display == "none") {
             theDIV.style.display = "block";
+            theDIV.style.zIndex = Utils.getNextZLevel();
             let aboutDIV = document.getElementById("aboutDIV");
             aboutDIV.style.display = "none";
         } else {
@@ -8588,8 +8598,13 @@ import { Utils } from "../shared/Utils.js";
         // condLog(SuperBigFamView.fanchartSettingsOptionsObject.getDefaultOptions());
         let theDIV = document.getElementById("legendDIV");
         // condLog("SETTINGS ARE:", theDIV.style.display);
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
         if (theDIV.style.display == "none") {
             theDIV.style.display = "block";
+            theDIV.style.zIndex = Utils.getNextZLevel();
         } else {
             theDIV.style.display = "none";
         }
@@ -11266,11 +11281,17 @@ import { Utils } from "../shared/Utils.js";
      * Show a popup for the person.
      */
     SuperBigFamView.personPopup = Tree.prototype.personPopup = function ( person ) {
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
+
         personPopup.popupHTML(person, {
             type: "CC",
             person: person,
             leafCollection: SuperBigFamView.theLeafCollection,
-            appID:APP_ID
+            appID:APP_ID, 
+            SettingsObj: Utils
         });
         console.log("SuperBigFamView.personPopup");
     }

--- a/views/superBigFamTree/SuperBigFamView.js
+++ b/views/superBigFamTree/SuperBigFamView.js
@@ -6237,7 +6237,7 @@ import { Utils } from "../shared/Utils.js";
                     }
                 }
                 console.log("ADDED ", numNewPeeps, " new peeps!");
-                console.log(result[0]);
+                // console.log(result[0]);
 
                 let needToReDoCall = false;
                 if (numNewPeeps >= 1000) {
@@ -6388,7 +6388,7 @@ import { Utils } from "../shared/Utils.js";
      */
     function loadDescendantsAtLevel(newLevel) {
         let newDescLevel = SuperBigFamView.numDescGens2Display;
-        console.log("Need to load MORE DESCENDANT peeps from Generation ", newLevel, newDescLevel);
+        // console.log("Need to load MORE DESCENDANT peeps from Generation ", newLevel, newDescLevel);
         if (SuperBigFamView.loadedLevels.indexOf("D" + newLevel) > -1) {
             // already loaded this level ... so let's just return and forget about it - no need to repeat the past
             SuperBigFamView.refreshTheLegend();
@@ -6442,7 +6442,7 @@ import { Utils } from "../shared/Utils.js";
     function loadCousinsAtLevel(newLevel) {
         const d = new Date();
         let ms = d.getUTCMinutes() + " : " + d.getUTCSeconds() + " : " + d.getUTCMilliseconds();
-        console.log("== function loadCousinsAtLevel --> Need to load MORE COUSINS peeps at LEVEL ", newLevel, ms);
+        // console.log("== function loadCousinsAtLevel --> Need to load MORE COUSINS peeps at LEVEL ", newLevel, ms);
         condLog(
             "At beginning of function loadCousinsAtLevel - primary has ",
             thePeopleList[SuperBigFamView.theLeafCollection["A0"].Id]._data.Children.length,
@@ -11293,7 +11293,7 @@ import { Utils } from "../shared/Utils.js";
             appID:APP_ID, 
             SettingsObj: Utils
         });
-        console.log("SuperBigFamView.personPopup");
+        // console.log("SuperBigFamView.personPopup");
     }
     
     function placeHolderFunction4Popup (person, xy, Code) {
@@ -12608,19 +12608,19 @@ import { Utils } from "../shared/Utils.js";
 
     SuperBigFamView.lastLegendColourHighlighted = "none";
     SuperBigFamView.toggleLegendOptionToHighlight = function (option = 0, legend = "?") {
-        console.log("Just clicked on LEGEND TOGGLE for ", { option }, { legend });
+        // console.log("Just clicked on LEGEND TOGGLE for ", { option }, { legend });
         if (SuperBigFamView.currentSettings["highlight_options_showHighlights"] == true) {
-            console.log("CANNOT show other highlights - must follow the Highlights By tab option");
+            // console.log("CANNOT show other highlights - must follow the Highlights By tab option");
         } else {
-            console.log("CAN show highlights - bring it on !!!");
+            // console.log("CAN show highlights - bring it on !!!");
             let highlightDescriptorDIV = document.getElementById("highlightDescriptor");
             if (SuperBigFamView.lastLegendColourHighlighted == option) {
-                console.log("Click OFF - hide highlight");
+                // console.log("Click OFF - hide highlight");
                 SuperBigFamView.lastLegendColourHighlighted = "none";
                 highlightDescriptorDIV.style.display = "none";
                 document.getElementById("highlightPeepsDescriptor").innerText = "";
             } else {
-                console.log("CLICK ON - SHOW a NEW COLOUR to Highlight!");
+                // console.log("CLICK ON - SHOW a NEW COLOUR to Highlight!");
                 SuperBigFamView.lastLegendColourHighlighted = option;
                 highlightDescriptorDIV.style.display = "block";
                 document.getElementById("highlightPeepsDescriptor").innerText = legend;

--- a/views/webs/WebsView.js
+++ b/views/webs/WebsView.js
@@ -5094,7 +5094,7 @@ import { Utils } from "../shared/Utils.js";
                 "webs"           
             );
 
-        console.log("WebsView.personPopup");
+        // console.log("WebsView.personPopup");
     };
     
     

--- a/views/webs/WebsView.js
+++ b/views/webs/WebsView.js
@@ -53,6 +53,7 @@
  */
 
 import { WTapps_Utils } from "../fanChart/WTapps_Utils.js";
+import { Utils } from "../shared/Utils.js";
 
 (function () {
     const APP_ID = "AncestorWebs";
@@ -772,7 +773,7 @@ import { WTapps_Utils } from "../fanChart/WTapps_Utils.js";
             '<DIV id=SummaryMessageArea style="text-align:center;"></DIV>';
 
         var aboutHTML =
-            '<div id=aboutDIV style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px;}">' +
+            '<div id=aboutDIV class="pop-up" style="display:none; position:absolute; right:20px; background-color:aliceblue; border: solid blue 4px; border-radius: 15px; padding: 15px; zIndex:9999}">' +
             `<span style="color:red; position:absolute; top:0.2em; right:0.6em; cursor:pointer;"><a onclick="WebsView.toggleAbout();">` +
             SVGbtnCLOSE +
             "</a></span>" +
@@ -824,9 +825,14 @@ import { WTapps_Utils } from "../fanChart/WTapps_Utils.js";
         WebsView.toggleAbout = function () {
             let aboutDIV = document.getElementById("aboutDIV");
             let settingsDIV = document.getElementById("settingsDIV");
+            if (!Utils.firstTreeAppPopUpPopped) {
+                $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+                Utils.firstTreeAppPopUpPopped = true;
+            }
             if (aboutDIV) {
                 if (aboutDIV.style.display == "none") {
                     aboutDIV.style.display = "block";
+                    aboutDIV.style.zIndex = Utils.getNextZLevel();
                     settingsDIV.style.display = "none";
                 } else {
                     aboutDIV.style.display = "none";
@@ -962,8 +968,13 @@ import { WTapps_Utils } from "../fanChart/WTapps_Utils.js";
             condLog(WebsView.websSettingsOptionsObject.getDefaultOptions());
             let theDIV = document.getElementById("settingsDIV");
             condLog("SETTINGS ARE:", theDIV.style.display);
+            if (!Utils.firstTreeAppPopUpPopped) {
+                $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+                Utils.firstTreeAppPopUpPopped = true;
+            }
             if (theDIV.style.display == "none") {
                 theDIV.style.display = "block";
+                theDIV.style.zIndex = Utils.getNextZLevel();
                 let aboutDIV = document.getElementById("aboutDIV");
                 aboutDIV.style.display = "none";
             } else {
@@ -5066,7 +5077,10 @@ import { WTapps_Utils } from "../fanChart/WTapps_Utils.js";
      * Show a popup for the person.
      */
     Tree.prototype.personPopup  = function (person) {
-        
+        if (!Utils.firstTreeAppPopUpPopped) {
+            $(document).off("keyup", Utils.closeTopPopup).on("keyup", Utils.closeTopPopup);
+            Utils.firstTreeAppPopUpPopped = true;
+        }
             personPopup.popupHTML(
                 person,
                 {
@@ -5074,6 +5088,7 @@ import { WTapps_Utils } from "../fanChart/WTapps_Utils.js";
                     ahNum: WebsView.myAhnentafel.listByPerson[person._data.Id],
                     primaryPerson: thePeopleList[WebsView.myAhnentafel.list[1]],
                     myAhnentafel: WebsView.myAhnentafel,
+                    SettingsObj: Utils
                 },
                 AboutAppIcon,
                 "webs"           


### PR DESCRIPTION
* Made dismissal of popups - person popups as well as settings pod and about pod, and connections popup - to act consistently with other tree apps
* --> dismiss with ESCAPE key (LIFO order), - or - by clicking on the cell in the Fan Chart or Tree that generated the popup in the first place

* Fixed issue with Safari and iOS and the FanChart and Fandoku - needed to add a class staticPosition, since those two apps need the .box class to act static and not relative
* removed some console.logs used for testing
* made marriage info in person popup same format as birth / death info