### PR TITLE
Don't hide main when printing

### DIFF
--- a/tree.css
+++ b/tree.css
@@ -495,7 +495,7 @@ ul.treeapp-tabs a:link {
   header,
   #header,
   #content,
-  main {
+  .page--content main {
     display: none;
   }
 


### PR DESCRIPTION
There are multiple `<main>` elements, so setting them all to `display:none` for print media now hides the tree.

This should fix https://github.com/wikitree/redesign-issues/issues/77

