### PR TITLE
Scope styles so rules never leak out into other trees

### DIFF
--- a/views/ahnentafel/ahnentafel.css
+++ b/views/ahnentafel/ahnentafel.css
@@ -1,4 +1,4 @@
-.highlighted {
+#ahnentafelAncestorList .highlighted {
   background-color: #fad158;
 }
 #view-container.ahnentafelView {

--- a/views/cc7/css/cc7.css
+++ b/views/cc7/css/cc7.css
@@ -866,45 +866,47 @@ div.cc7Table .cc7filter-row th {
    Print styles
    ---------------------------------------------------------*/
 @media print {
-  * {
-    color: #000 !important;
-    box-shadow: none !important;
-    text-shadow: none !important;
-    /* background:transparent !important;*/
-  }
-  html {
-    background-color: #fff;
-  }
-  /* Hide navigation */
-  :root:has(#cc7Container) nav {
-    display: none;
-  }
+  :root:has(#cc7Container) {
+    * {
+      color: #000 !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      /* background:transparent !important;*/
+    }
+    html {
+      background-color: #fff;
+    }
+    /* Hide navigation */
+    nav {
+      display: none;
+    }
 
-  /* Show link destinations in brackets after the link text */
-  /* a[href]:after { content: " (" attr(href) ") "; }*/
-  a[href] {
-    font-weight: bold;
-    text-decoration: underline;
-    color: #06c;
-    border: none;
-  }
-  /* Don't show link destinations for JavaScript or internal links */
-  a[href^="javascript:"]:after,
-  a[href^="#"]:after {
-    content: "";
-  }
+    /* Show link destinations in brackets after the link text */
+    /* a[href]:after { content: " (" attr(href) ") "; }*/
+    a[href] {
+      font-weight: bold;
+      text-decoration: underline;
+      color: #06c;
+      border: none;
+    }
+    /* Don't show link destinations for JavaScript or internal links */
+    a[href^="javascript:"]:after,
+    a[href^="#"]:after {
+      content: "";
+    }
 
-  /* Show abbr title value in brackets after the text */
-  abbr[title]:after {
-    content: " (" attr(title) ")";
-  }
+    /* Show abbr title value in brackets after the text */
+    abbr[title]:after {
+      content: " (" attr(title) ")";
+    }
 
-  figure {
-    margin-bottom: 1em;
-    overflow: hidden;
-  }
+    figure {
+      margin-bottom: 1em;
+      overflow: hidden;
+    }
 
-  figure img {
-    border: 1px solid #000;
+    figure img {
+      border: 1px solid #000;
+    }
   }
 }

--- a/views/familyCalendar/calendar.css
+++ b/views/familyCalendar/calendar.css
@@ -3,7 +3,7 @@
   width: 300px;
 }
 
-.calendar {
+#watchCalendar .calendar {
   display: none;
   height: 100%;
 }
@@ -12,7 +12,7 @@
   width: 100px;
 }
 
-.loader {
+#watchCalendar .loader {
   width: 101px;
   position: relative;
   -webkit-animation: spin 4s linear infinite;
@@ -41,7 +41,7 @@
   }
 }
 
-.content {
+#watchCalendar .content {
   padding: 0 18px;
   display: none;
   overflow: hidden;

--- a/views/familyView/familyView.css
+++ b/views/familyView/familyView.css
@@ -67,12 +67,31 @@
 }
 
 @media print {
-  header {
-    display: none !important;
-  }
+  :root:has(#family_group) {
+    header {
+      display: none !important;
+    }
 
-  main {
-    font-size: 90%;
+    main {
+      font-size: 90%;
+    }
+
+    #view-container {
+      width: 100% !important;
+      padding: 0 !important;
+      margin: 0 !important;
+      border: 0 !important;
+      font-size: 80%;
+    }
+
+    .icon {
+      display: none;
+    }
+
+    a:link, a:visited, a {
+      color: black;
+      text-decoration: none;
+    }
   }
 
   #family_group {
@@ -107,20 +126,4 @@
     font-size: 80%;
   }
 
-  #view-container {
-    width: 100% !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    border: 0 !important;
-    font-size: 80%;
-  }
-
-  .icon {
-    display: none;
-  }
-
-  a:link, a:visited, a {
-    color: black;
-    text-decoration: none;
-  }
 }

--- a/views/heritage/heritage.css
+++ b/views/heritage/heritage.css
@@ -185,6 +185,6 @@ div.heritage select {
   display: none;
 }
 
-.center {
+#heritageContainer .center {
   text-align: center;
 }

--- a/views/oneNameTrees/oneNameTrees.css
+++ b/views/oneNameTrees/oneNameTrees.css
@@ -1,6 +1,6 @@
 /* Normalise */
-input[type="button"],
-input[type="submit"],
+.oneNameTrees input[type="button"],
+.oneNameTrees input[type="submit"],
 .oneNameTrees #controls button,
 .oneNameTrees #help button,
 .oneNameTrees #helpButton,

--- a/views/stats/sortable-theme-slick.css
+++ b/views/stats/sortable-theme-slick.css
@@ -1,109 +1,111 @@
-/* line 2, ../sass/_sortable.sass */
-table[data-sortable] {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-/* line 6, ../sass/_sortable.sass */
-table[data-sortable] th {
-  vertical-align: bottom;
-  font-weight: bold;
-}
-/* line 10, ../sass/_sortable.sass */
-table[data-sortable] th, table[data-sortable] td {
-  text-align: left;
-  padding: 10px;
-}
-/* line 14, ../sass/_sortable.sass */
-table[data-sortable] th:not([data-sortable="false"]) {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
-  user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  -webkit-touch-callout: none;
-  cursor: pointer;
-}
-/* line 26, ../sass/_sortable.sass */
-table[data-sortable] th:after {
-  content: "";
-  visibility: hidden;
-  display: inline-block;
-  vertical-align: inherit;
-  height: 0;
-  width: 0;
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent;
-  margin-right: 1px;
-  margin-left: 10px;
-  float: right;
-}
-/* line 40, ../sass/_sortable.sass */
-table[data-sortable] th[data-sorted="true"]:after {
-  visibility: visible;
-}
-/* line 43, ../sass/_sortable.sass */
-table[data-sortable] th[data-sorted-direction="descending"]:after {
-  border-top-color: inherit;
-  margin-top: 8px;
-}
-/* line 47, ../sass/_sortable.sass */
-table[data-sortable] th[data-sorted-direction="ascending"]:after {
-  border-bottom-color: inherit;
-  margin-top: 3px;
-}
+#statsContainer {
+  /* line 2, ../sass/_sortable.sass */
+  table[data-sortable] {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+  /* line 6, ../sass/_sortable.sass */
+  table[data-sortable] th {
+    vertical-align: bottom;
+    font-weight: bold;
+  }
+  /* line 10, ../sass/_sortable.sass */
+  table[data-sortable] th, table[data-sortable] td {
+    text-align: left;
+    padding: 10px;
+  }
+  /* line 14, ../sass/_sortable.sass */
+  table[data-sortable] th:not([data-sortable="false"]) {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-touch-callout: none;
+    cursor: pointer;
+  }
+  /* line 26, ../sass/_sortable.sass */
+  table[data-sortable] th:after {
+    content: "";
+    visibility: hidden;
+    display: inline-block;
+    vertical-align: inherit;
+    height: 0;
+    width: 0;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent;
+    margin-right: 1px;
+    margin-left: 10px;
+    float: right;
+  }
+  /* line 40, ../sass/_sortable.sass */
+  table[data-sortable] th[data-sorted="true"]:after {
+    visibility: visible;
+  }
+  /* line 43, ../sass/_sortable.sass */
+  table[data-sortable] th[data-sorted-direction="descending"]:after {
+    border-top-color: inherit;
+    margin-top: 8px;
+  }
+  /* line 47, ../sass/_sortable.sass */
+  table[data-sortable] th[data-sorted-direction="ascending"]:after {
+    border-bottom-color: inherit;
+    margin-top: 3px;
+  }
 
-/* line 6, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick {
-  color: #333333;
-  background: white;
-  border: 1px solid #e0e0e0;
-}
-/* line 11, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick thead th {
-  background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ffffff), color-stop(100%, #eeeeee));
-  background-image: -webkit-linear-gradient(#ffffff, #eeeeee);
-  background-image: -moz-linear-gradient(#ffffff, #eeeeee);
-  background-image: -o-linear-gradient(#ffffff, #eeeeee);
-  background-image: linear-gradient(#ffffff, #eeeeee);
-  background-color: #f0f0f0;
-  border-bottom: 1px solid #e0e0e0;
-}
-/* line 16, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick tbody td {
-  border-top: 1px solid #e0e0e0;
-}
-/* line 19, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick tbody > tr:nth-child(odd) > td {
-  background-color: #f9f9f9;
-}
-/* line 22, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick th[data-sorted="true"] {
-  -webkit-box-shadow: inset 1px 0 #bce8f1, inset -1px 0 #bce8f1;
-  -moz-box-shadow: inset 1px 0 #bce8f1, inset -1px 0 #bce8f1;
-  box-shadow: inset 1px 0 #bce8f1, inset -1px 0 #bce8f1;
-  color: #3a87ad;
-  background: #d9edf7;
-  border-bottom-color: #bce8f1;
-}
-/* line 28, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick th[data-sorted="true"]:first-child {
-  -webkit-box-shadow: inset -1px 0 #bce8f1;
-  -moz-box-shadow: inset -1px 0 #bce8f1;
-  box-shadow: inset -1px 0 #bce8f1;
-}
-/* line 31, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick th[data-sorted="true"]:last-child {
-  -webkit-box-shadow: inset 1px 0 #bce8f1;
-  -moz-box-shadow: inset 1px 0 #bce8f1;
-  box-shadow: inset 1px 0 #bce8f1;
-}
-/* line 34, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick th[data-sorted="true"][data-sorted-direction="descending"]:after {
-  border-top-color: #3a87ad;
-}
-/* line 37, ../sass/sortable-theme-slick.sass */
-table[data-sortable].sortable-theme-slick th[data-sorted="true"][data-sorted-direction="ascending"]:after {
-  border-bottom-color: #3a87ad;
+  /* line 6, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick {
+    color: #333333;
+    background: white;
+    border: 1px solid #e0e0e0;
+  }
+  /* line 11, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick thead th {
+    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ffffff), color-stop(100%, #eeeeee));
+    background-image: -webkit-linear-gradient(#ffffff, #eeeeee);
+    background-image: -moz-linear-gradient(#ffffff, #eeeeee);
+    background-image: -o-linear-gradient(#ffffff, #eeeeee);
+    background-image: linear-gradient(#ffffff, #eeeeee);
+    background-color: #f0f0f0;
+    border-bottom: 1px solid #e0e0e0;
+  }
+  /* line 16, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick tbody td {
+    border-top: 1px solid #e0e0e0;
+  }
+  /* line 19, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick tbody > tr:nth-child(odd) > td {
+    background-color: #f9f9f9;
+  }
+  /* line 22, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick th[data-sorted="true"] {
+    -webkit-box-shadow: inset 1px 0 #bce8f1, inset -1px 0 #bce8f1;
+    -moz-box-shadow: inset 1px 0 #bce8f1, inset -1px 0 #bce8f1;
+    box-shadow: inset 1px 0 #bce8f1, inset -1px 0 #bce8f1;
+    color: #3a87ad;
+    background: #d9edf7;
+    border-bottom-color: #bce8f1;
+  }
+  /* line 28, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick th[data-sorted="true"]:first-child {
+    -webkit-box-shadow: inset -1px 0 #bce8f1;
+    -moz-box-shadow: inset -1px 0 #bce8f1;
+    box-shadow: inset -1px 0 #bce8f1;
+  }
+  /* line 31, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick th[data-sorted="true"]:last-child {
+    -webkit-box-shadow: inset 1px 0 #bce8f1;
+    -moz-box-shadow: inset 1px 0 #bce8f1;
+    box-shadow: inset 1px 0 #bce8f1;
+  }
+  /* line 34, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick th[data-sorted="true"][data-sorted-direction="descending"]:after {
+    border-top-color: #3a87ad;
+  }
+  /* line 37, ../sass/sortable-theme-slick.sass */
+  table[data-sortable].sortable-theme-slick th[data-sorted="true"][data-sorted-direction="ascending"]:after {
+    border-bottom-color: #3a87ad;
+  }
 }

--- a/views/surnames/surnames.css
+++ b/views/surnames/surnames.css
@@ -27,27 +27,27 @@
 .newSurname {
   font-weight: bold;
 }
-.gen0 {
+#surnamesList .gen0 {
   font-size: 70px;
 }
-.gen1 {
+#surnamesList .gen1 {
   font-size: 60px;
 }
-.gen2 {
+#surnamesList .gen2 {
   font-size: 50px;
 }
-.gen3 {
+#surnamesList .gen3 {
   font-size: 40px;
 }
-.gen4 {
+#surnamesList .gen4 {
   font-size: 30px;
 }
-.gen5 {
+#surnamesList .gen5 {
   font-size: 20px;
 }
-.gen6 {
+#surnamesList .gen6 {
   font-size: 16px;
 }
-.genx {
+#surnamesList .genx {
   font-size: 14px;
 }


### PR DESCRIPTION
Various trees had some vary broad style rules that did, or could, interfere with styling from other trees. Specifically:

* cc7.css had style rules in `@media print` that affected everything
* familyView.css had the same
* ahfenatal.css styled very generic classes "highlighted"
* calendar.css styled very generic classes "calendar" "loader" and "content"
* heritaage.css styled very generic classes "center"
* oneNameTree styled all input buttons
* generational statistics styled any tables with a particular data element.

All of these are now scoped so their rules will only apply if that treeview is the one currently loaded.