### PR TITLE
SlippyTree fixes for apps.wikitree.com

### DIFF
--- a/views/slippyTree/style.css
+++ b/views/slippyTree/style.css
@@ -11,6 +11,7 @@
 /* Rules for both the original and the dev-2025 TreeApps page */
 :root.slippy-tree-root {
     --background-color: white;          /* a "default" background of white */
+    height: 100%;
 }
 /*
 This is not a nice thing to do, but without it you can zoom away the full-screen button.
@@ -19,34 +20,35 @@ However it's an issue on all tree apps, not just this one. Leave it off for now
     touch-action: none;
 }
 */
-:root.slippy-tree-root:has(body.tree-apps) {
-    height: 100%;
-     --content-padding: 0;
+:root.slippy-tree-root:has(.tree-apps) {
      --background-color: #f0f0ef;       /* background in actual site */
 }
-:root.slippy-tree-root body.tree-apps {
+:root.slippy-tree-root body {
     display: flex;
     flex-direction: column;
     height: 100%;
 }
-:root.slippy-tree-root body.tree-apps #view-container {
+:root.slippy-tree-root body #view-container {
     flex: 1;
     min-height: auto;
     margin: 0;
 }
-:root.slippy-tree-root body.tree-apps #main {
+:root.slippy-tree-root main {
+     --content-padding: 0;      /* Set here, no higher, as apps.wikitree.com uses this in header */
+}
+:root.slippy-tree-root body #main {
     padding-bottom: 0;
     flex: 1;
     display: flex;
      --background-color: #f7f6f0;       /* background in the new site */
 }
-:root.slippy-tree-root body.tree-apps #main .row {
+:root.slippy-tree-root body #main .row {
     --bs-gutter-x: 0px;
     --bs-gutter-y: 0px;
     flex: 1;
     margin-top: 0 !important; /* Bootstrap is awful */
 }
-:root.slippy-tree-root body.tree-apps #main .row > * {
+:root.slippy-tree-root body #main .row > * {
     display: flex;
     flex-direction: column;
 }
@@ -92,6 +94,7 @@ However it's an issue on all tree apps, not just this one. Leave it off for now
         margin-top: 0;
     }
 }
+ 
 
 /**
  * Below here everything is prefixed with .slippy-tree-container.


### PR DESCRIPTION
https://github.com/wikitree/wikitree-dynamic-tree/pull/323 caused problems for slippytree when running in apps.wikitree.com due to the differences between the DOM on that site and the DOM on the real site.

Now working in both.
