### PR TITLE
Assorted Tree Apps bug fixes

### DIFF
--- a/views/cc7/js/cc7.js
+++ b/views/cc7/js/cc7.js
@@ -1981,7 +1981,7 @@ class CC7 {
         const loggedInUser = window.wtViewRegistry.session.lm.user.name;
         const currentId = wtViewRegistry.getCurrentWtId();
         const trueSize = currentId == loggedInUser ? CC7.getCC7Total() : "";
-        const showWarn = (trueSize && trueSize >= 10000) || (!trueSize && window.people.size > 9500);
+        const showWarn = window.people.size > 9500 && (!trueSize || trueSize >= 10000);
         const rowSpan = $("#trTot").length == 0 ? 2 : 3;
         let msgHtml = `True CC7 size for ${currentId} = ${trueSize ? trueSize : "[not available]"}</br>`;
         if (showWarn) {

--- a/views/compactCouplesTree/cct_explorer.js
+++ b/views/compactCouplesTree/cct_explorer.js
@@ -39,15 +39,6 @@ export class CCTE {
     // whenever one clicks in a person box (i.e. when the person pop-up is generated).
     static addTestInfo = typeof debugLoggingOn != "undefined" && debugLoggingOn && true;
 
-    static originOffsetX = 500;
-    static originOffsetY = 300;
-    static boxWidth = 200;
-    static boxHeight = 52;
-    static halfBoxWidth = CCTE.boxWidth / 2;
-    static halfBoxHeight = CCTE.boxHeight / 2;
-    static nodeWidth = CCTE.boxWidth * 1.5;
-    static nodeHeight = CCTE.boxHeight * 3;
-
     static ANCESTORS = 1;
     static DESCENDANTS = -1;
     static #COOKIE_NAME = "wt_cct_options";
@@ -735,16 +726,18 @@ export class CCTE {
     /**
      * Main WikiTree API calls
      */
+    static ADDITIONAL_FIELDS = ["BirthDateDecade", "DeathDateDecade", "IsLiving", "NoChildren", "Privacy"];
+
     async getFullPerson(id) {
-        return await CachedPerson.getWithLoad(id, ["Parents", "Spouses", "Children"]);
+        return await CachedPerson.getWithLoad(id, ["Parents", "Spouses", "Children"], CCTE.ADDITIONAL_FIELDS);
     }
 
     async getWithSpousesAndChildren(id) {
-        return await CachedPerson.getWithLoad(id, ["Spouses", "Children"]);
+        return await CachedPerson.getWithLoad(id, ["Spouses", "Children"], CCTE.ADDITIONAL_FIELDS);
     }
 
     async getWithSpouses(id) {
-        return await CachedPerson.getWithLoad(id, ["Spouses"]);
+        return await CachedPerson.getWithLoad(id, ["Spouses"], CCTE.ADDITIONAL_FIELDS);
     }
 
     static getD3Children(couple, alreadyInTree) {
@@ -790,7 +783,6 @@ export class CCTE {
             minBirthYear: 5000,
             maxGeneration: 0,
             duplicates: new Map(),
-            profileCount: 0,
         };
         // Clear each person's generation info and add them to the byWtId map
         for (const person of people.values()) {
@@ -808,13 +800,12 @@ export class CCTE {
             if (p.isDuplicate() && !tInfo.duplicates.has(id)) {
                 tInfo.duplicates.set(id, ++n);
             }
-            tInfo.profileCount += p.getNrCopies(tInfo.maxGeneration);
             const bYear = +p.getBirthYear();
             if (bYear > 0 && bYear < tInfo.minBirthYear) {
                 tInfo.minBirthYear = bYear;
             }
         }
-        // console.log(`nr profiles=${tInfo.profileCount}, nr duplicates=${tInfo.duplicates.size}`);
+        // console.log(`nr duplicates=${tInfo.duplicates.size}`);
         // console.log(`generation counts: ${tInfo.genCounts}`, tInfo.genCounts);
 
         return tInfo;

--- a/views/compactCouplesTree/cct_view.js
+++ b/views/compactCouplesTree/cct_view.js
@@ -5,33 +5,9 @@ import { CCTE } from "./cct_explorer.js";
 
 window.CCTView = class CCTView extends View {
     static #DESCRIPTION = "";
-    static WANTED_PRIMARY_FIELDS = [
-        "BirthDate",
-        "BirthDateDecade",
-        "DeathDateDecade",
-        "BirthLocation",
-        "DataStatus",
-        "DeathDate",
-        "DeathLocation",
-        "Derived.BirthName",
-        "Derived.BirthNamePrivate",
-        "Father",
-        "FirstName",
-        "Gender",
-        "HasChildren",
-        "IsLiving",
-        "Id",
-        "LastNameAtBirth",
-        "LastNameCurrent",
-        "MiddleInitial",
-        "Mother",
-        "Name",
-        "Privacy",
-        "Suffix",
-    ];
     constructor() {
         super();
-        CachedPerson.init(new PeopleCache(new CacheLoader(CCTView.WANTED_PRIMARY_FIELDS)));
+        CachedPerson.init(new PeopleCache(new CacheLoader()));
     }
 
     meta() {

--- a/views/compactDescendantsTree/ccd_view.js
+++ b/views/compactDescendantsTree/ccd_view.js
@@ -5,33 +5,9 @@ import { CCDE } from "./ccd_explorer.js";
 
 window.CCDView = class CCDView extends View {
     static #DESCRIPTION = "";
-    static WANTED_PRIMARY_FIELDS = [
-        "BirthDate",
-        "BirthDateDecade",
-        "DeathDateDecade",
-        "BirthLocation",
-        "DataStatus",
-        "DeathDate",
-        "DeathLocation",
-        "Derived.BirthName",
-        "Derived.BirthNamePrivate",
-        "Father",
-        "FirstName",
-        "Gender",
-        "HasChildren",
-        "IsLiving",
-        "Id",
-        "LastNameAtBirth",
-        "LastNameCurrent",
-        "MiddleInitial",
-        "Mother",
-        "Name",
-        "Privacy",
-        "Suffix",
-    ];
     constructor() {
         super();
-        CachedPerson.init(new PeopleCache(new CacheLoader(CCDView.WANTED_PRIMARY_FIELDS)));
+        CachedPerson.init(new PeopleCache(new CacheLoader()));
     }
 
     meta() {

--- a/views/compactDescendantsTree/display.js
+++ b/views/compactDescendantsTree/display.js
@@ -71,6 +71,9 @@ export function showTree(ccde, treeInfo, connectors = false, hideTreeHeader = fa
 
     const treeHeight = calculateTreeHeight(theTree.genCounts);
     const [treeWidth, svgWidth] = calculateWidths();
+    console.log(
+        `currentMaxShowGen=${currentMaxShowGen}, treeHeight=${treeHeight}, treeWidth = ${treeWidth}, svgWidth = ${svgWidth}`
+    );
 
     // append the svg object to the body of the page
     // appends a 'group' element to 'svg'

--- a/views/couplesTree/cache_loader.js
+++ b/views/couplesTree/cache_loader.js
@@ -20,7 +20,6 @@ export class CacheLoader {
         "MiddleInitial",
         "Mother",
         "Name",
-        "Photo",
         "Suffix",
     ];
     static DEFAULT_VARIABLE_FIELDS = ["Parents", "Spouses", "Children"];

--- a/views/couplesTree/couples_tree.js
+++ b/views/couplesTree/couples_tree.js
@@ -748,15 +748,15 @@ window.CouplesTreeView = class CouplesTreeView extends View {
          */
 
         async getFullPerson(id) {
-            return await CachedPerson.getWithLoad(id, ["Parents", "Spouses", "Children"]);
+            return await CachedPerson.getWithLoad(id, ["Parents", "Spouses", "Children"], ["Photo"]);
         }
 
         async getWithSpousesAndChildren(id) {
-            return await CachedPerson.getWithLoad(id, ["Spouses", "Children"]);
+            return await CachedPerson.getWithLoad(id, ["Spouses", "Children"], ["Photo"]);
         }
 
         async getWithSpouses(id) {
-            return await CachedPerson.getWithLoad(id, ["Spouses"]);
+            return await CachedPerson.getWithLoad(id, ["Spouses"], ["Photo"]);
         }
     }); // End CoupleTreeViewer class definition
 


### PR DESCRIPTION
* Large CC7 warning is only shown when necessary
* Fixed SVG width calculation in Compact Descendants (CCD)
* Corrected number of generations calculation in CCD
* Fixed No "no more children" brick wall selection in Compact Ancestors and CCD
* Removed dead code

These changes also affected the Dynamic Couples Tree (due to shared code), but no functionality change and  can be tested at https://apps.wikitree.com/apps/smit641/cct/