### PR TITLE
Fix Dynamic Couple Tree bugs

### DIFF
--- a/views/couplesTree/couples_tree.css
+++ b/views/couplesTree/couples_tree.css
@@ -131,6 +131,9 @@
 .cvtc .children-list li {
   margin: 6px;
 }
+.cvtc .children-list-wrapper {
+  z-index: 500 !important;
+}
 .cvtc .children-list-wrapper h4 {
   margin: 12px;
   background: #f9f9f9;

--- a/views/couplesTree/couples_tree.js
+++ b/views/couplesTree/couples_tree.js
@@ -1389,15 +1389,10 @@ window.CouplesTreeView = class CouplesTreeView extends View {
             });
         }
         /**
-         * Remove all popups. It will also remove
-         * any popups displayed by other trees on the
-         * page which is what we want. If later we
-         * decide we don't want that then we can just
-         * add the selector class to each popup and
-         * select on it, like we do with nodes and links.
+         * Remove all person popups.
          */
         removePopups() {
-            d3.selectAll(".popup").remove();
+            d3.selectAll(".popup-layer .person-popup").remove();
         }
     } // End Tree class definition
 


### PR DESCRIPTION
* Ensure children list are overlaying person boxes in production where boxes have a z-index of 100
* Correct clearing of person detail popups

These changes are on https://apps.wikitree.com/apps/smit641/cct/#name=Smit-53&view=couples but the first change can only be verified in production.