### PR TITLE
Update couples_tree.js

### DIFF
--- a/views/couplesTree/couples_tree.js
+++ b/views/couplesTree/couples_tree.js
@@ -448,8 +448,8 @@ window.CouplesTreeView = class CouplesTreeView extends View {
                 .style("position", "absolute")
                 .style("top", 0)
                 .style("left", 0)
-                .style("width", width + "px")
-                .style("height", height + "px");
+                .style("width", 0)
+                .style("height", 0);
 
             this.g = g;
             this.htmlLayer = htmlLayer;


### PR DESCRIPTION
Prevent the htmlLayer container from obscuring part of the SVG.

Previously the bottom right quadrant of the display was obscured by the container, preventing expand buttons in this area from being accessible. They now work as can be seen at https://apps.wikitree.com/apps/smit641/cct/#name=Smit-9251&view=couples