### PR TITLE
Update usgenweb.js

### DIFF
--- a/views/research/sites/usgenweb.js
+++ b/views/research/sites/usgenweb.js
@@ -6,7 +6,7 @@ window.ResearchSites.push({
     group: "General",
 
     buildUrl(data) {
-        const baseUrl = "https://www.usgwarchives.net/search/search.cgi/search.htm";
+        const baseUrl = "http://www.usgwarchives.net/search/search.cgi/search.htm";
 
         const params = {
             cmd: "Search!",


### PR DESCRIPTION
The USGenWeb Archives Project still operates over plain HTTP only and does not support HTTPS, so the link has been updated to use http:// instead of https://.